### PR TITLE
View & edit roster positions and trade line items

### DIFF
--- a/priv/static/js/app.js
+++ b/priv/static/js/app.js
@@ -11780,9 +11780,9 @@ channel.join().receive("ok", function (resp) {
 exports.default = socket;
 });
 
-;require.alias("jquery/dist/jquery.js", "jquery");
+;require.alias("phoenix/priv/static/phoenix.js", "phoenix");
 require.alias("phoenix_html/priv/static/phoenix_html.js", "phoenix_html");
-require.alias("phoenix/priv/static/phoenix.js", "phoenix");
+require.alias("jquery/dist/jquery.js", "jquery");
 require.alias("process/browser.js", "process");process = require('process');require.register("___globals___", function(exports, require, module) {
   
 });})();require('___globals___');

--- a/web/admin/fantasy_team.ex
+++ b/web/admin/fantasy_team.ex
@@ -5,5 +5,38 @@ defmodule Ex338.ExAdmin.FantasyTeam do
 
   register_resource Ex338.FantasyTeam do
 
+    show fantasy_team do
+      attributes_table do
+        row :id
+        row :team_name
+        row :waiver_position
+        row :fantasy_league
+      end
+      panel "Roster Positions" do
+        table_for(Enum.sort(fantasy_team.roster_positions, &(&1.position <= &2.position))) do
+          column "Id", fn(position) ->
+             Phoenix.HTML.safe_to_string(Phoenix.HTML.Link.link "#{position.id}", to: "/admin/roster_positions/#{position.id}/edit")
+          end
+          column "Position", fn(position) ->
+            "#{position.position}"
+          end
+          column "Fantasy Player", fn(position) ->
+            "#{position.fantasy_player.player_name}"
+          end
+          column "Sports League", fn(position) ->
+            "#{position.fantasy_player.sports_league.league_name}"
+          end
+        end
+      end
+    end
+
+    query do
+      %{
+        all: [preload: [:fantasy_league, roster_positions: [fantasy_player: :sports_league]]],
+      }
+    end
   end
 end
+
+
+

--- a/web/admin/trade.ex
+++ b/web/admin/trade.ex
@@ -27,6 +27,29 @@ defmodule Ex338.ExAdmin.Trade do
         row :status
         row :additional_terms
       end
+      panel "Trade Line Items" do
+        table_for(trade.trade_line_items) do
+          column "Id", fn(line_item) ->
+             Phoenix.HTML.safe_to_string(Phoenix.HTML.Link.link "#{line_item.id}", to: "/admin/trade_line_items/#{line_item.id}/edit")
+          end
+          column "Fantasy Team", fn (line_item) ->
+            "#{line_item.fantasy_team.team_name}"
+          end
+          column "Action", fn (line_item) ->
+            "#{line_item.action}"
+          end
+          column "Fantasy Player", fn (line_item) ->
+            "#{line_item.fantasy_player.player_name}"
+          end
+        end
+      end
+    end
+
+    query do
+      %{
+        all: [preload: [trade_line_items: [:fantasy_team,
+                         fantasy_player: :sports_league]]],
+      }
     end
   end
 end


### PR DESCRIPTION
* Enables admin to see the roster positions for a team
* Admin can click to edit each roster position
* Enables admin to see the trade line items for a trade
* Admin can click to edit each trade line item