### PR TITLE
Add status and released_at to RosterPosition table

### DIFF
--- a/priv/repo/migrations/20160921232648_add_status_and_date_to_roster_position.exs
+++ b/priv/repo/migrations/20160921232648_add_status_and_date_to_roster_position.exs
@@ -1,0 +1,10 @@
+defmodule Ex338.Repo.Migrations.AddStatusAndDateToRosterPosition do
+  use Ecto.Migration
+
+  def change do
+    alter table(:roster_positions) do
+      add :status, :string, default: "active"
+      add :released_at, :datetime
+    end
+  end
+end

--- a/test/models/fantasy_team_repo_test.exs
+++ b/test/models/fantasy_team_repo_test.exs
@@ -15,4 +15,22 @@ defmodule Ex338.FantasyTeamRepoTest do
       assert Repo.all(query) == ~w(a b c)
     end
   end
+  describe "right_join_players_by_league/1" do
+    test "returns all players and any owners in a league" do
+      player_a = insert(:fantasy_player, player_name: "A")
+      player_b = insert(:fantasy_player, player_name: "B")
+      _player_c = insert(:fantasy_player, player_name: "C")
+      f_league_a = insert(:fantasy_league)
+      f_league_b = insert(:fantasy_league)
+      team_a = insert(:fantasy_team, fantasy_league: f_league_a)
+      team_b = insert(:fantasy_team, fantasy_league: f_league_b)
+      insert(:roster_position, fantasy_team: team_a, fantasy_player: player_a)
+      insert(:roster_position, fantasy_team: team_b, fantasy_player: player_b)
+
+      results = FantasyTeam.right_join_players_by_league(f_league_a.id)
+                |> Repo.all
+
+      assert Enum.map(results, &(&1.player_name)) == ~w(A B C)
+    end
+  end
 end

--- a/web/controllers/fantasy_player_controller.ex
+++ b/web/controllers/fantasy_player_controller.ex
@@ -6,8 +6,8 @@ defmodule Ex338.FantasyPlayerController do
   def index(conn, %{"fantasy_league_id" => league_id}) do
     fantasy_league = FantasyLeague |> Repo.get(league_id)
 
-    fantasy_players = FantasyTeam
-                      |> FantasyTeam.right_join_players_by_league(league_id)
+    fantasy_players = league_id
+                      |> FantasyTeam.right_join_players_by_league
                       |> Repo.all
                       |> Enum.group_by(fn %{league_name: league_name} -> league_name end)
 

--- a/web/models/fantasy_team.ex
+++ b/web/models/fantasy_team.ex
@@ -3,7 +3,8 @@ defmodule Ex338.FantasyTeam do
 
   use Ex338.Web, :model
 
-  alias Ex338.{FantasyLeague, DraftPick, Waiver, RosterPosition, Owner}
+  alias Ex338.{FantasyLeague, DraftPick, Waiver, RosterPosition, Owner,
+               FantasyTeam}
 
   schema "fantasy_teams" do
     field :team_name, :string
@@ -39,10 +40,11 @@ defmodule Ex338.FantasyTeam do
     from t in query, order_by: t.team_name
   end
 
-  def right_join_players_by_league(query, fantasy_league_id) do
-    from t in query,
+  def right_join_players_by_league(fantasy_league_id) do
+    from t in FantasyTeam,
     left_join: r in RosterPosition,
-    on: r.fantasy_team_id == t.id and t.fantasy_league_id == ^fantasy_league_id,
+    on: r.fantasy_team_id == t.id and t.fantasy_league_id == ^fantasy_league_id
+      and r.status == "active",
     right_join: p in assoc(r, :fantasy_player),
     inner_join: s in assoc(p, :sports_league),
     select: %{team_name: t.team_name, player_name: p.player_name,

--- a/web/models/roster_position.ex
+++ b/web/models/roster_position.ex
@@ -10,10 +10,14 @@ defmodule Ex338.RosterPosition do
   @positions ["CL", "CBB", "CFB", "CHK", "EPL", "KD", "LLWS", "MTn", "MLB",
               "NBA", "NFL", "NHL", "PGA", "WTn"] ++ @flex_positions
 
+  @status_options ["active", "dropped", "released"]
+
   schema "roster_positions" do
     belongs_to :fantasy_team, FantasyTeam
     field :position, :string
     belongs_to :fantasy_player, FantasyPlayer
+    field :status, :string
+    field :released_at, Ecto.DateTime
 
     timestamps()
   end


### PR DESCRIPTION
* status and released_at columns will be used instead of delete
* keeps track of why a player is no longer with a team
* keeps track of when they left the team
* defaults to "active"
* Updated query to only include active players
* Closes #58