### PR TITLE
Add dues and winnings received for fantasy teams

### DIFF
--- a/priv/repo/migrations/20160928222113_add_winnings_dues_to_fantasy_team.exs
+++ b/priv/repo/migrations/20160928222113_add_winnings_dues_to_fantasy_team.exs
@@ -1,0 +1,10 @@
+defmodule Ex338.Repo.Migrations.AddWinningsDuesToFantasyTeam do
+  use Ecto.Migration
+
+  def change do
+    alter table(:fantasy_teams) do
+      add :dues_paid, :decimal, default: 0
+      add :winnings_received, :decimal, default: 0
+    end
+  end
+end

--- a/test/controllers/fantasy_league_controller_test.exs
+++ b/test/controllers/fantasy_league_controller_test.exs
@@ -23,13 +23,15 @@ defmodule Ex338.FantasyLeagueControllerTest do
     test "shows league and lists all fantasy teams", %{conn: conn} do
       league = insert(:fantasy_league)
       team_1 = insert(:fantasy_team, team_name: "Brown", fantasy_league: league)
-      team_2 = insert(:fantasy_team, team_name: "Axel", fantasy_league: league)
+      team_2 = insert(:fantasy_team, team_name: "Axel", fantasy_league: league,
+                                     dues_paid: 100)
 
       conn = get conn, fantasy_league_path(conn, :show, league.id)
 
       assert html_response(conn, 200) =~ ~r/Fantasy League/
       assert String.contains?(conn.resp_body, team_1.team_name)
       assert String.contains?(conn.resp_body, team_2.team_name)
+      assert String.contains?(conn.resp_body, "100")
     end
   end
 end

--- a/test/controllers/fantasy_team_controller_test.exs
+++ b/test/controllers/fantasy_team_controller_test.exs
@@ -30,7 +30,8 @@ defmodule Ex338.FantasyTeamControllerTest do
   describe "show/2" do
     test "shows fantasy team info and players' table", %{conn: conn} do
       league = insert(:fantasy_league)
-      team = insert(:fantasy_team, team_name: "Brown", fantasy_league: league)
+      team = insert(:fantasy_team, team_name: "Brown", fantasy_league: league,
+                                   winnings_received: 75, dues_paid: 100)
       insert(:owner, user: conn.assigns.current_user, fantasy_team: team)
       player = insert(:fantasy_player)
       insert(:roster_position, position: "Unassigned", fantasy_team: team,
@@ -42,6 +43,8 @@ defmodule Ex338.FantasyTeamControllerTest do
       assert String.contains?(conn.resp_body, team.team_name)
       assert String.contains?(conn.resp_body, conn.assigns.current_user.name)
       assert String.contains?(conn.resp_body, player.player_name)
+      assert String.contains?(conn.resp_body, "75")
+      assert String.contains?(conn.resp_body, "100")
     end
   end
 

--- a/web/admin/fantasy_team.ex
+++ b/web/admin/fantasy_team.ex
@@ -11,6 +11,8 @@ defmodule Ex338.ExAdmin.FantasyTeam do
         row :team_name
         row :waiver_position
         row :fantasy_league
+        row :dues_paid
+        row :winnings_received
       end
       panel "Roster Positions" do
         table_for(Enum.sort(fantasy_team.roster_positions, &(&1.position <= &2.position))) do
@@ -32,7 +34,8 @@ defmodule Ex338.ExAdmin.FantasyTeam do
 
     query do
       %{
-        all: [preload: [:fantasy_league, roster_positions: [fantasy_player: :sports_league]]],
+        all: [preload: [:fantasy_league, roster_positions:
+             [fantasy_player: :sports_league]]],
       }
     end
   end

--- a/web/models/fantasy_team.ex
+++ b/web/models/fantasy_team.ex
@@ -9,6 +9,8 @@ defmodule Ex338.FantasyTeam do
   schema "fantasy_teams" do
     field :team_name, :string
     field :waiver_position, :integer
+    field :dues_paid, :decimal
+    field :winnings_received, :decimal
     belongs_to :fantasy_league, FantasyLeague
     has_many :roster_positions, RosterPosition
     has_many :fantasy_players, through: [:roster_positions, :fantasy_player]
@@ -25,7 +27,8 @@ defmodule Ex338.FantasyTeam do
   """
   def changeset(struct, params \\ %{}) do
     struct
-    |> cast(params, [:team_name, :waiver_position, :fantasy_league_id])
+    |> cast(params, [:team_name, :waiver_position, :fantasy_league_id,
+                     :dues_paid, :winnings_received])
     |> validate_required([:team_name, :waiver_position])
   end
 

--- a/web/static/css/_fantasy_teams.scss
+++ b/web/static/css/_fantasy_teams.scss
@@ -71,5 +71,11 @@
     }
   }
 }
+.dues {
+  display: none;
+  @include media ($medium-screen) {
+    display: table-cell;
+  }
+}
 
 

--- a/web/templates/fantasy_league/fantasy_teams_table.html.eex
+++ b/web/templates/fantasy_league/fantasy_teams_table.html.eex
@@ -4,9 +4,10 @@
       <tr>
         <th>Rank</th>
         <th>Name</th>
+        <th class="dues">Dues Paid ($)</th>
         <th>Waiver Position</th>
         <th>Points</th>
-        <th>Winnings</th>
+        <th>Winnings ($)</th>
       </tr>
     </thead>
     <tbody>
@@ -14,6 +15,7 @@
         <tr>
           <td>-</td>
           <td><%= link team.team_name, to: fantasy_team_path(@conn, :show, team.id) %></td>
+          <td class="dues"><%= team.dues_paid %></td>
           <td><%= team.waiver_position %></td>
           <td>-</td>
           <td>-</td>

--- a/web/templates/fantasy_team/show.html.eex
+++ b/web/templates/fantasy_team/show.html.eex
@@ -8,6 +8,8 @@
 <% end %>
 
 <p><strong>Waiver Position: </strong><%= @fantasy_team.waiver_position %>
+<p><strong>Winnings/Received: </strong>$0 / $<%= @fantasy_team.winnings_received %>
+<p><strong>Dues Paid: </strong>$<%= @fantasy_team.dues_paid %>
 
 <%= if (owner?(@current_user, @fantasy_team) || @current_user.admin == true) do %>
 <p><%= link "Update Team and Roster", to: fantasy_team_path(@conn, :edit, 


### PR DESCRIPTION
* Commish can track league dues and teams can see who has paid
* Commish can track winnings paid to fantasy teams
* Dues visible on standings to create social encouragement to pay
* Winnings only on fantasy team show since only the team cares
* Dues hidden on small mobile due to screen size constraints
* Closes #50