### PR TITLE
Add Waiver new and create actions to processes waivers

### DIFF
--- a/lib/waiver_admin.ex
+++ b/lib/waiver_admin.ex
@@ -1,4 +1,6 @@
 defmodule Ex338.WaiverAdmin do
+  @moduledoc false
+
   alias Ecto.Multi
   import Ecto.Query
   alias Ex338.{Waiver, RosterPosition, FantasyTeam, Repo}
@@ -91,5 +93,44 @@ defmodule Ex338.WaiverAdmin do
   defp league_teams_count(%FantasyTeam{fantasy_league_id: league_id}) do
     query = from f in FantasyTeam, where: f.fantasy_league_id == ^league_id
     Repo.aggregate(query, :count, :id)
+  end
+
+  def set_datetime_to_process(
+    %{"add_fantasy_player_id" => player_id} = params, team_id) do
+
+    datetime_to_process =
+      get_existing_waiver_date(team_id, player_id) || three_days_from_now
+
+    Map.put(params, "process_at", datetime_to_process)
+  end
+
+  def set_datetime_to_process(params, _team_id) do
+    Map.put(params, "process_at", three_days_from_now)
+  end
+
+  defp get_existing_waiver_date(fantasy_team_id, add_player_id) do
+    league_id = Repo.get!(FantasyTeam, fantasy_team_id).fantasy_league_id
+
+    waiver =
+      add_player_id
+      |> Waiver.pending_waivers_for_player(league_id)
+      |> Repo.one
+
+    case waiver do
+      nil    -> nil
+      waiver -> waiver.process_at
+    end
+  end
+
+  defp three_days_from_now do
+    three_days = (86_400*3)
+    now = Ecto.DateTime.utc
+          |> Ecto.DateTime.to_erl
+          |> Calendar.DateTime.from_erl!("UTC")
+
+    now
+    |> Calendar.DateTime.add!(three_days)
+    |> Calendar.DateTime.to_erl
+    |> Ecto.DateTime.from_erl
   end
 end

--- a/lib/waiver_admin.ex
+++ b/lib/waiver_admin.ex
@@ -1,0 +1,95 @@
+defmodule Ex338.WaiverAdmin do
+  alias Ecto.Multi
+  import Ecto.Query
+  alias Ex338.{Waiver, RosterPosition, FantasyTeam, Repo}
+
+  def process_waiver(waiver, %{"status" => "successful"} = params) do
+
+    Multi.new
+    |> update_waiver_status(waiver, params)
+    |> insert_new_position(waiver)
+    |> drop_roster_position(waiver)
+    |> update_league_waivers(waiver)
+    |> update_team_waiver_position(waiver)
+    |> Repo.transaction
+  end
+
+  def process_waiver(waiver, params) do
+
+    Multi.new
+    |> update_waiver_status(waiver, params)
+    |> Repo.transaction
+  end
+
+  defp update_waiver_status(multi, waiver, params) do
+    multi
+    |> Multi.update(:waiver, Waiver.changeset(waiver, params))
+  end
+
+  defp insert_new_position(multi, %Waiver{add_fantasy_player_id: nil}) do
+    multi
+  end
+
+  defp insert_new_position(multi, waiver) do
+    position_params = Map.new
+                      |> Map.put("fantasy_team_id", waiver.fantasy_team_id)
+                      |> Map.put("fantasy_player_id", waiver.add_fantasy_player_id)
+
+    changeset = RosterPosition.changeset(%RosterPosition{},position_params)
+
+    Multi.insert(multi, :new_roster_position, changeset)
+  end
+
+  defp drop_roster_position(multi, %Waiver{drop_fantasy_player: nil}) do
+    multi
+  end
+
+  defp drop_roster_position(multi, waiver) do
+    dropped_position =
+      RosterPosition
+      |> Repo.get_by!(%{fantasy_team_id: waiver.fantasy_team_id,
+                        fantasy_player_id: waiver.drop_fantasy_player.id})
+
+    changeset = RosterPosition.changeset(
+      dropped_position, %{status: "dropped", released_at: Ecto.DateTime.utc})
+
+    multi
+    |> Multi.update(:delete_roster_position, changeset)
+  end
+
+  defp update_league_waivers(multi, %Waiver{add_fantasy_player: nil}) do
+    multi
+  end
+
+  defp update_league_waivers(multi, %Waiver{fantasy_team: fantasy_team}) do
+    changeset = update_league_waiver_positions(fantasy_team)
+
+    multi
+    |> Multi.update_all(:league_waiver_update, changeset, [])
+  end
+
+  def update_league_waiver_positions(
+    %FantasyTeam{waiver_position: position, fantasy_league_id: league_id}) do
+     from f in FantasyTeam,
+       where: f.waiver_position > ^position,
+       where: f.fantasy_league_id == ^league_id,
+       update: [inc: [waiver_position: -1]]
+  end
+
+  defp update_team_waiver_position(multi, %Waiver{add_fantasy_player: nil}) do
+    multi
+  end
+
+  defp update_team_waiver_position(multi, %Waiver{fantasy_team: fantasy_team}) do
+    team_count = league_teams_count(fantasy_team)
+    changeset = Ecto.Changeset.change(fantasy_team, waiver_position: team_count)
+
+    multi
+    |> Multi.update(:team_waiver_update, changeset)
+  end
+
+  defp league_teams_count(%FantasyTeam{fantasy_league_id: league_id}) do
+    query = from f in FantasyTeam, where: f.fantasy_league_id == ^league_id
+    Repo.aggregate(query, :count, :id)
+  end
+end

--- a/priv/repo/migrations/20161002161106_add_process_at_to_waiver.exs
+++ b/priv/repo/migrations/20161002161106_add_process_at_to_waiver.exs
@@ -1,0 +1,9 @@
+defmodule Ex338.Repo.Migrations.AddProcessAtToWaiver do
+  use Ecto.Migration
+
+  def change do
+    alter table(:waivers) do
+      add :process_at, :datetime
+    end
+  end
+end

--- a/test/controllers/fantasy_team_controller_test.exs
+++ b/test/controllers/fantasy_team_controller_test.exs
@@ -34,8 +34,12 @@ defmodule Ex338.FantasyTeamControllerTest do
                                    winnings_received: 75, dues_paid: 100)
       insert(:owner, user: conn.assigns.current_user, fantasy_team: team)
       player = insert(:fantasy_player)
+      dropped_player = insert(:fantasy_player)
       insert(:roster_position, position: "Unassigned", fantasy_team: team,
                                           fantasy_player: player)
+      insert(:roster_position, fantasy_team: team,
+                               fantasy_player: dropped_player,
+                               status: "dropped")
 
       conn = get conn, fantasy_team_path(conn, :show, team.id)
 
@@ -43,6 +47,7 @@ defmodule Ex338.FantasyTeamControllerTest do
       assert String.contains?(conn.resp_body, team.team_name)
       assert String.contains?(conn.resp_body, conn.assigns.current_user.name)
       assert String.contains?(conn.resp_body, player.player_name)
+      refute String.contains?(conn.resp_body, dropped_player.player_name)
       assert String.contains?(conn.resp_body, "75")
       assert String.contains?(conn.resp_body, "100")
     end

--- a/test/controllers/waiver_controller_test.exs
+++ b/test/controllers/waiver_controller_test.exs
@@ -1,6 +1,6 @@
 defmodule Ex338.WaiverControllerTest do
   use Ex338.ConnCase
-  alias Ex338.{Waiver, User}
+  alias Ex338.{Waiver, User, RosterPosition, FantasyTeam}
 
   setup %{conn: conn} do
     user = %User{name: "test", email: "test@example.com", id: 1}
@@ -131,6 +131,149 @@ defmodule Ex338.WaiverControllerTest do
       waiver = insert(:waiver)
 
       conn = get conn, waiver_path(conn, :edit, waiver.id)
+
+      assert html_response(conn, 302) =~ ~r/redirected/
+    end
+  end
+
+  describe "update/2" do
+    test "processes a successful waiver", %{conn: conn} do
+      conn = put_in(conn.assigns.current_user.admin, true)
+      league = insert(:fantasy_league)
+      team_a = insert(:fantasy_team, waiver_position: 2, fantasy_league: league)
+      team_b = insert(:fantasy_team, waiver_position: 1, fantasy_league: league)
+      team_c = insert(:fantasy_team, waiver_position: 3, fantasy_league: league)
+      player_a = insert(:fantasy_player)
+      player_b = insert(:fantasy_player)
+      position = insert(:roster_position, fantasy_team: team_a,
+                                          fantasy_player: player_a)
+      waiver = insert(:waiver, fantasy_team: team_a,
+                               drop_fantasy_player: player_a,
+                               add_fantasy_player:  player_b)
+      params = %{status: "successful"}
+
+      conn = patch conn, waiver_path(conn, :update, waiver.id, waiver: params)
+
+      assert redirected_to(conn) == fantasy_league_waiver_path(conn, :index,
+                                      team_a.fantasy_league_id)
+      assert Repo.get!(Waiver, waiver.id).status == "successful"
+      assert Repo.get!(RosterPosition, position.id).status == "dropped"
+      assert Repo.get!(FantasyTeam, team_a.id).waiver_position == 3
+      assert Repo.get!(FantasyTeam, team_b.id).waiver_position == 1
+      assert Repo.get!(FantasyTeam, team_c.id).waiver_position == 2
+      assert Repo.aggregate(RosterPosition, :count, :id) == 2
+    end
+
+    test "processes a successful waiver with only a drop", %{conn: conn} do
+      conn = put_in(conn.assigns.current_user.admin, true)
+      league = insert(:fantasy_league)
+      team_a = insert(:fantasy_team, waiver_position: 2, fantasy_league: league)
+      team_b = insert(:fantasy_team, waiver_position: 1, fantasy_league: league)
+      team_c = insert(:fantasy_team, waiver_position: 3, fantasy_league: league)
+      player_a = insert(:fantasy_player)
+      position = insert(:roster_position, fantasy_team: team_a,
+                                          fantasy_player: player_a)
+      waiver = insert(:waiver, fantasy_team: team_a,
+                               drop_fantasy_player: player_a,
+                               add_fantasy_player:  nil)
+      params = %{status: "successful"}
+
+      conn = patch conn, waiver_path(conn, :update, waiver.id, waiver: params)
+
+      assert redirected_to(conn) == fantasy_league_waiver_path(conn, :index,
+                                      team_a.fantasy_league_id)
+      assert Repo.get!(Waiver, waiver.id).status == "successful"
+      assert Repo.get!(RosterPosition, position.id).status == "dropped"
+      assert Repo.get!(FantasyTeam, team_a.id).waiver_position == 2
+      assert Repo.get!(FantasyTeam, team_b.id).waiver_position == 1
+      assert Repo.get!(FantasyTeam, team_c.id).waiver_position == 3
+      assert Repo.aggregate(RosterPosition, :count, :id) == 1
+    end
+
+    test "processes a successful waiver with only an add", %{conn: conn} do
+      conn = put_in(conn.assigns.current_user.admin, true)
+      league = insert(:fantasy_league)
+      team_a = insert(:fantasy_team, waiver_position: 2, fantasy_league: league)
+      team_b = insert(:fantasy_team, waiver_position: 1, fantasy_league: league)
+      team_c = insert(:fantasy_team, waiver_position: 3, fantasy_league: league)
+      player_a = insert(:fantasy_player)
+      player_b = insert(:fantasy_player)
+      insert(:roster_position, fantasy_team: team_a,
+                               fantasy_player: player_a)
+      waiver = insert(:waiver, fantasy_team: team_a,
+                               drop_fantasy_player: nil,
+                               add_fantasy_player:  player_b)
+
+      params = %{status: "successful"}
+
+      conn = patch conn, waiver_path(conn, :update, waiver.id, waiver: params)
+
+      assert redirected_to(conn) == fantasy_league_waiver_path(conn, :index,
+                                      team_a.fantasy_league_id)
+      assert Repo.get!(Waiver, waiver.id).status == "successful"
+      assert Repo.get!(FantasyTeam, team_a.id).waiver_position == 3
+      assert Repo.get!(FantasyTeam, team_b.id).waiver_position == 1
+      assert Repo.get!(FantasyTeam, team_c.id).waiver_position == 2
+      assert Repo.aggregate(RosterPosition, :count, :id) == 2
+    end
+
+    test "processes an invalid waiver", %{conn: conn} do
+      conn = put_in(conn.assigns.current_user.admin, true)
+      league = insert(:fantasy_league)
+      team_a = insert(:fantasy_team, waiver_position: 2, fantasy_league: league)
+      team_b = insert(:fantasy_team, waiver_position: 1, fantasy_league: league)
+      team_c = insert(:fantasy_team, waiver_position: 3, fantasy_league: league)
+      player_a = insert(:fantasy_player)
+      player_b = insert(:fantasy_player)
+      insert(:roster_position, fantasy_team: team_a,
+                                          fantasy_player: player_a)
+      waiver = insert(:waiver, fantasy_team: team_a,
+                               drop_fantasy_player: player_a,
+                               add_fantasy_player:  player_b)
+      params = %{status: "invalid"}
+
+      conn = patch conn, waiver_path(conn, :update, waiver.id, waiver: params)
+
+      assert redirected_to(conn) == fantasy_league_waiver_path(conn, :index,
+                                      team_a.fantasy_league_id)
+      assert Repo.get!(Waiver, waiver.id).status == "invalid"
+      assert Repo.get!(FantasyTeam, team_a.id).waiver_position == 2
+      assert Repo.get!(FantasyTeam, team_b.id).waiver_position == 1
+      assert Repo.get!(FantasyTeam, team_c.id).waiver_position == 3
+      assert Repo.aggregate(RosterPosition, :count, :id) == 1
+    end
+
+    test "processes unsuccessful waiver", %{conn: conn} do
+      conn = put_in(conn.assigns.current_user.admin, true)
+      league = insert(:fantasy_league)
+      team_a = insert(:fantasy_team, waiver_position: 2, fantasy_league: league)
+      team_b = insert(:fantasy_team, waiver_position: 1, fantasy_league: league)
+      team_c = insert(:fantasy_team, waiver_position: 3, fantasy_league: league)
+      player_a = insert(:fantasy_player)
+      player_b = insert(:fantasy_player)
+      insert(:roster_position, fantasy_team: team_a,
+                                          fantasy_player: player_a)
+      waiver = insert(:waiver, fantasy_team: team_a,
+                               drop_fantasy_player: player_a,
+                               add_fantasy_player:  player_b)
+      params = %{status: "unsuccessful"}
+
+      conn = patch conn, waiver_path(conn, :update, waiver.id, waiver: params)
+
+      assert redirected_to(conn) == fantasy_league_waiver_path(conn, :index,
+                                      team_a.fantasy_league_id)
+      assert Repo.get!(Waiver, waiver.id).status == "unsuccessful"
+      assert Repo.get!(FantasyTeam, team_a.id).waiver_position == 2
+      assert Repo.get!(FantasyTeam, team_b.id).waiver_position == 1
+      assert Repo.get!(FantasyTeam, team_c.id).waiver_position == 3
+      assert Repo.aggregate(RosterPosition, :count, :id) == 1
+    end
+
+    test "redirects to root if user is not admin", %{conn: conn} do
+      waiver = insert(:waiver)
+      params = %{status: "higher priority claim submitted"}
+
+      conn = patch conn, waiver_path(conn, :update, waiver.id, waiver: params)
 
       assert html_response(conn, 302) =~ ~r/redirected/
     end

--- a/test/lib/waiver_admin_test.exs
+++ b/test/lib/waiver_admin_test.exs
@@ -1,0 +1,39 @@
+defmodule Ex338.WaiverAdminTest do
+  use Ex338.ModelCase
+  alias Ex338.{WaiverAdmin}
+
+  describe "set_datetime_to_process/2" do
+    test "adds the datetime to process 3 days from now if no existing" do
+      params = %{"add_fantasy_player_id" => 1}
+      team = insert(:fantasy_team)
+
+      result = WaiverAdmin.set_datetime_to_process(params, team.id)
+
+      assert Map.get(result, "process_at") > Ecto.DateTime.utc
+    end
+
+    test "adds existing datetime if there is an existing waiver for a player" do
+      date = Ecto.DateTime.cast!(
+        %{day: 17, hour: 14, min: 0, month: 4, sec: 0, year: 2010})
+      league = insert(:fantasy_league)
+      team = insert(:fantasy_team, fantasy_league: league)
+      player = insert(:fantasy_player)
+      insert(:waiver, fantasy_team: team, add_fantasy_player: player,
+                      status: "pending", process_at: date)
+      params = %{"add_fantasy_player_id" => player.id}
+
+      result = WaiverAdmin.set_datetime_to_process(params, team.id)
+
+      assert Map.get(result, "process_at") == date
+    end
+
+    test "adds the datetime even if just dropping a player" do
+      params = %{"drop_fantasy_player_id" => 1}
+      team = insert(:fantasy_team)
+
+      result = WaiverAdmin.set_datetime_to_process(params, team.id)
+
+      assert Map.get(result, "process_at") > Ecto.DateTime.utc
+    end
+  end
+end

--- a/test/models/fantasy_player_repo_test.exs
+++ b/test/models/fantasy_player_repo_test.exs
@@ -33,12 +33,15 @@ defmodule Ex338.FantasyPlayerRepoTest do
       player_a = insert(:fantasy_player, sports_league: league_a)
       player_b = insert(:fantasy_player, sports_league: league_a)
       player_c = insert(:fantasy_player, sports_league: league_b)
+      player_d = insert(:fantasy_player, sports_league: league_b)
       f_league_a = insert(:fantasy_league)
       f_league_b = insert(:fantasy_league)
       team_a = insert(:fantasy_team, fantasy_league: f_league_a)
       team_b = insert(:fantasy_team, fantasy_league: f_league_b)
       insert(:roster_position, fantasy_team: team_a, fantasy_player: player_a)
       insert(:roster_position, fantasy_team: team_b, fantasy_player: player_b)
+      insert(:roster_position, fantasy_team: team_a, fantasy_player: player_d,
+                               status: "dropped")
 
       query = FantasyPlayer.available_players(f_league_a.id)
 
@@ -46,7 +49,9 @@ defmodule Ex338.FantasyPlayerRepoTest do
         %{player_name: player_b.player_name, league_abbrev: league_a.abbrev,
           id: player_b.id},
         %{player_name: player_c.player_name, league_abbrev: league_b.abbrev,
-          id: player_c.id}
+          id: player_c.id},
+        %{player_name: player_d.player_name, league_abbrev: league_b.abbrev,
+          id: player_d.id}
       ]
     end
   end

--- a/test/models/fantasy_team_repo_test.exs
+++ b/test/models/fantasy_team_repo_test.exs
@@ -55,4 +55,24 @@ defmodule Ex338.FantasyTeamRepoTest do
       ]
     end
   end
+
+  describe "preload_active_positions/1" do
+    test "only returns active roster positions" do
+      player_a = insert(:fantasy_player)
+      player_b = insert(:fantasy_player)
+      player_c = insert(:fantasy_player)
+      team = insert(:fantasy_team, team_name: "A")
+      insert(:roster_position, fantasy_team: team, fantasy_player: player_a,
+                               status: "active")
+      insert(:roster_position, fantasy_team: team, fantasy_player: player_b,
+                               status: "dropped")
+      insert(:roster_position, fantasy_team: team, fantasy_player: player_c,
+                               status: "traded")
+
+      query = FantasyTeam |> FantasyTeam.preload_active_positions
+      result = Repo.one!(query)
+
+      assert Enum.count(result.roster_positions) == 1
+    end
+  end
 end

--- a/test/models/roster_position_repo_test.exs
+++ b/test/models/roster_position_repo_test.exs
@@ -1,0 +1,23 @@
+defmodule Ex338.RosterPositionRepoTest do
+  use Ex338.ModelCase
+  alias Ex338.{RosterPosition}
+
+  describe "active_roster_positions/1" do
+    test "only returns active roster positions" do
+      player_a = insert(:fantasy_player)
+      player_b = insert(:fantasy_player)
+      player_c = insert(:fantasy_player)
+      team = insert(:fantasy_team)
+      insert(:roster_position, fantasy_team: team, fantasy_player: player_a,
+                               status: "active")
+      insert(:roster_position, fantasy_team: team, fantasy_player: player_b,
+                               status: "dropped")
+      insert(:roster_position, fantasy_team: team, fantasy_player: player_c,
+                               status: "traded")
+
+      query = RosterPosition.active_positions(RosterPosition)
+
+      assert Repo.aggregate(query, :count, :id) == 1
+    end
+  end
+end

--- a/test/models/waiver_test.exs
+++ b/test/models/waiver_test.exs
@@ -6,13 +6,37 @@ defmodule Ex338.WaiverTest do
   @valid_attrs %{fantasy_team_id: 1}
   @invalid_attrs %{}
 
-  test "changeset with valid attributes" do
-    changeset = Waiver.changeset(%Waiver{}, @valid_attrs)
-    assert changeset.valid?
+  describe "changeset/2" do
+    test "changeset with valid attributes" do
+      changeset = Waiver.changeset(%Waiver{}, @valid_attrs)
+      assert changeset.valid?
+    end
+
+    test "changeset with invalid attributes" do
+      changeset = Waiver.changeset(%Waiver{}, @invalid_attrs)
+      refute changeset.valid?
+    end
   end
 
-  test "changeset with invalid attributes" do
-    changeset = Waiver.changeset(%Waiver{}, @invalid_attrs)
-    refute changeset.valid?
+  describe "new_changeset/2" do
+    test "changeset with valid attributes" do
+      changeset = Waiver.new_changeset(%Waiver{}, @valid_attrs)
+      assert changeset.valid?
+    end
+
+    test "changeset with invalid attributes" do
+      changeset = Waiver.new_changeset(%Waiver{}, @invalid_attrs)
+      refute changeset.valid?
+    end
+  end
+
+  describe "set_datetime_to_process/1" do
+    test "takes a changeset and add a time 3 days in future" do
+      changeset = Ecto.Changeset.cast(%Waiver{}, @valid_attrs, [:fantasy_team_id])
+
+      result = Waiver.set_datetime_to_process(changeset)
+
+      assert result.changes.process_at > Ecto.DateTime.utc
+    end
   end
 end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -108,6 +108,7 @@ defmodule Ex338.Factory do
       fantasy_team:          build(:fantasy_team),
       add_fantasy_player:    build(:fantasy_player),
       drop_fantasy_player:   build(:fantasy_player),
+      process_at: Ecto.DateTime.utc,
     }
   end
 

--- a/test/views/view_helpers_test.exs
+++ b/test/views/view_helpers_test.exs
@@ -69,4 +69,15 @@ defmodule Ex338.ViewHelpersViewTest do
       assert result == "Sep 16, 2017"
     end
   end
+
+  describe "short_datetime_pst/1" do
+    test "formats DateTime struct into short datetime in PST" do
+      date = Ecto.DateTime.cast!(
+        %{day: 16, hour: 22, min: 30, month: 9, sec: 0, year: 2017})
+
+      result = ViewHelpers.short_datetime_pst(date)
+
+      assert result == "Sep 16, 2017  3:30 PM"
+    end
+  end
 end

--- a/web/controllers/fantasy_team_controller.ex
+++ b/web/controllers/fantasy_team_controller.ex
@@ -1,7 +1,8 @@
 defmodule Ex338.FantasyTeamController do
   use Ex338.Web, :controller
 
-  alias Ex338.{FantasyTeam, FantasyLeague, Authorization, RosterAdmin}
+  alias Ex338.{FantasyTeam, FantasyLeague, Authorization, RosterAdmin,
+               RosterPosition}
 
   import Canary.Plugs
 
@@ -14,7 +15,7 @@ defmodule Ex338.FantasyTeamController do
 
     fantasy_teams = FantasyTeam
                     |> FantasyLeague.by_league(league_id)
-                    |> preload(roster_positions: [fantasy_player: :sports_league])
+                    |> FantasyTeam.preload_active_positions
                     |> FantasyTeam.alphabetical
                     |> Repo.all
                     |> RosterAdmin.add_open_positions_to_teams
@@ -24,9 +25,10 @@ defmodule Ex338.FantasyTeamController do
   end
 
   def show(conn, %{"id" => id}) do
+
     team = FantasyTeam
-           |> preload([[roster_positions: [fantasy_player: :sports_league]],
-                       [owners: :user], :fantasy_league])
+           |> FantasyTeam.preload_active_positions
+           |> preload([[owners: :user], :fantasy_league])
            |> Repo.get!(id)
            |> RosterAdmin.add_open_positions_to_team
 

--- a/web/controllers/fantasy_team_controller.ex
+++ b/web/controllers/fantasy_team_controller.ex
@@ -1,8 +1,7 @@
 defmodule Ex338.FantasyTeamController do
   use Ex338.Web, :controller
 
-  alias Ex338.{FantasyTeam, FantasyLeague, Authorization, RosterAdmin,
-               RosterPosition}
+  alias Ex338.{FantasyTeam, FantasyLeague, Authorization, RosterAdmin}
 
   import Canary.Plugs
 

--- a/web/controllers/waiver_controller.ex
+++ b/web/controllers/waiver_controller.ex
@@ -2,7 +2,7 @@ defmodule Ex338.WaiverController do
   use Ex338.Web, :controller
 
   alias Ex338.{FantasyLeague, FantasyTeam, FantasyPlayer, Waiver, Authorization,
-               NotificationEmail}
+               NotificationEmail, WaiverAdmin}
 
   import Canary.Plugs
 
@@ -92,5 +92,21 @@ defmodule Ex338.WaiverController do
     changeset = Waiver.changeset(waiver)
 
     render(conn, "edit.html", waiver: waiver, changeset: changeset)
+  end
+
+  def update(conn,%{"id" => _, "waiver" => params}) do
+    waiver = conn.assigns.waiver
+
+    result = WaiverAdmin.process_waiver(waiver, params)
+
+    case result do
+      {:ok,  %{waiver: _waiver}} ->
+        conn
+        |> put_flash(:info, "Waiver successfully processed")
+        |> redirect(to: fantasy_league_waiver_path(conn, :index,
+                        waiver.fantasy_team.fantasy_league_id))
+      {:error, _, changeset, _} ->
+        render(conn, "edit.html", waiver: waiver, changeset: changeset)
+    end
   end
 end

--- a/web/controllers/waiver_controller.ex
+++ b/web/controllers/waiver_controller.ex
@@ -54,6 +54,7 @@ defmodule Ex338.WaiverController do
 
   def create(conn, %{"fantasy_team_id" => team_id, "waiver" => waiver_params}) do
     fantasy_team = conn.assigns.fantasy_team
+    waiver_params = waiver_params |> WaiverAdmin.set_datetime_to_process(team_id)
 
     result = fantasy_team
              |> build_assoc(:waivers)

--- a/web/controllers/waiver_controller.ex
+++ b/web/controllers/waiver_controller.ex
@@ -10,6 +10,10 @@ defmodule Ex338.WaiverController do
     preload: [:owners], persisted: true, id_name: "fantasy_team_id",
     unauthorized_handler: {Authorization, :handle_unauthorized}
 
+  plug :load_and_authorize_resource, model: Waiver, only: [:edit, :update],
+    preload: [:fantasy_team, :add_fantasy_player, :drop_fantasy_player],
+    unauthorized_handler: {Authorization, :handle_unauthorized}
+
   def index(conn, %{"fantasy_league_id" => league_id}) do
     fantasy_league = FantasyLeague |> Repo.get(league_id)
 
@@ -44,8 +48,7 @@ defmodule Ex338.WaiverController do
                              fantasy_team: fantasy_team,
                              fantasy_league: fantasy_league,
                              owned_players: owned_players,
-                             avail_players: avail_players
-    )
+                             avail_players: avail_players)
   end
 
   def create(conn, %{"fantasy_team_id" => team_id, "waiver" => waiver_params}) do
@@ -76,13 +79,18 @@ defmodule Ex338.WaiverController do
                          |> FantasyPlayer.available_players
                          |> Repo.all
 
-        render(conn, "new.html",
-          changeset: changeset,
-          fantasy_team: fantasy_team,
-          fantasy_league: fantasy_league,
-          owned_players: owned_players,
-          avail_players: avail_players
-        )
+        render(conn, "new.html", changeset: changeset,
+                                 fantasy_team: fantasy_team,
+                                 fantasy_league: fantasy_league,
+                                 owned_players: owned_players,
+                                 avail_players: avail_players)
     end
+  end
+
+  def edit(conn, _) do
+    waiver    = conn.assigns.waiver
+    changeset = Waiver.changeset(waiver)
+
+    render(conn, "edit.html", waiver: waiver, changeset: changeset)
   end
 end

--- a/web/controllers/waiver_controller.ex
+++ b/web/controllers/waiver_controller.ex
@@ -20,7 +20,8 @@ defmodule Ex338.WaiverController do
     waivers =
       Waiver
       |> Waiver.by_league(league_id)
-      |> preload([:fantasy_team, :add_fantasy_player, :drop_fantasy_player])
+      |> preload([:fantasy_team, [add_fantasy_player: :sports_league],
+                 [drop_fantasy_player: :sports_league]])
       |> Repo.all
 
     render(conn, "index.html", fantasy_league: fantasy_league,

--- a/web/models/abilities.ex
+++ b/web/models/abilities.ex
@@ -1,7 +1,9 @@
 defimpl Canada.Can, for: Ex338.User do
-  alias Ex338.{User, DraftPick, FantasyTeam}
+  alias Ex338.{User, DraftPick, FantasyTeam, Waiver}
 
   def can?(%User{admin: true}, _, _), do: true
+
+  def can?(_, action, %Waiver{}) when action in [:edit, :update], do: false
 
   def can?(%User{id: user_id}, action, model)
     when action in [:edit, :update, :create, :new] do

--- a/web/models/fantasy_player.ex
+++ b/web/models/fantasy_player.ex
@@ -39,7 +39,8 @@ defmodule Ex338.FantasyPlayer do
   def available_players(fantasy_league_id) do
     from t in FantasyTeam,
     left_join: r in RosterPosition,
-    on: r.fantasy_team_id == t.id and t.fantasy_league_id == ^fantasy_league_id,
+    on: r.fantasy_team_id == t.id and r.status == "active" and
+      t.fantasy_league_id == ^fantasy_league_id,
     right_join: p in assoc(r, :fantasy_player),
     inner_join: s in assoc(p, :sports_league),
     where: is_nil(r.fantasy_team_id),

--- a/web/models/fantasy_team.ex
+++ b/web/models/fantasy_team.ex
@@ -53,6 +53,13 @@ defmodule Ex338.FantasyTeam do
       order_by: [s.abbrev, p.player_name]
   end
 
+  def preload_active_positions(query) do
+    active_positions = RosterPosition.active_positions(RosterPosition)
+
+    from t in query,
+      preload: [roster_positions: ^active_positions]
+  end
+
   def right_join_players_by_league(fantasy_league_id) do
     from t in FantasyTeam,
       left_join: r in RosterPosition,

--- a/web/models/roster_position.ex
+++ b/web/models/roster_position.ex
@@ -10,7 +10,7 @@ defmodule Ex338.RosterPosition do
   @positions ["CL", "CBB", "CFB", "CHK", "EPL", "KD", "LLWS", "MTn", "MLB",
               "NBA", "NFL", "NHL", "PGA", "WTn"] ++ @flex_positions
 
-  @status_options ["active", "dropped", "released"]
+  @status_options ["active", "dropped", "traded"]
 
   schema "roster_positions" do
     belongs_to :fantasy_team, FantasyTeam
@@ -27,8 +27,9 @@ defmodule Ex338.RosterPosition do
   """
   def changeset(struct, params \\ %{}) do
     struct
-    |> cast(params, [:position, :fantasy_team_id, :fantasy_player_id])
-    |> validate_required([:position, :fantasy_team_id])
+    |> cast(params, [:position, :fantasy_team_id, :fantasy_player_id, :status,
+                     :released_at])
+    |> validate_required([:fantasy_team_id])
   end
 
   def positions, do: @positions

--- a/web/models/roster_position.ex
+++ b/web/models/roster_position.ex
@@ -35,4 +35,10 @@ defmodule Ex338.RosterPosition do
   def positions, do: @positions
 
   def flex_positions, do: @flex_positions
+
+  def active_positions(query) do
+    from r in query,
+      where: r.status == "active",
+      preload: [fantasy_player: :sports_league]
+  end
 end

--- a/web/models/waiver.ex
+++ b/web/models/waiver.ex
@@ -1,9 +1,10 @@
 defmodule Ex338.Waiver do
   use Ex338.Web, :model
 
-  @status_options ["pending", "successful",
-                   "higher priority claim submitted",
-                   "invalid claim"]
+  @status_options ["pending",
+                   "successful",
+                   "unsuccessful",
+                   "invalid"]
 
   schema "waivers" do
     belongs_to :fantasy_team, Ex338.FantasyTeam

--- a/web/models/waiver.ex
+++ b/web/models/waiver.ex
@@ -11,6 +11,7 @@ defmodule Ex338.Waiver do
     belongs_to :add_fantasy_player, Ex338.FantasyPlayer
     belongs_to :drop_fantasy_player, Ex338.FantasyPlayer
     field :status, :string
+    field :process_at, Ecto.DateTime
 
     timestamps()
   end

--- a/web/models/waiver.ex
+++ b/web/models/waiver.ex
@@ -44,7 +44,7 @@ defmodule Ex338.Waiver do
     from w in query,
       join: f in assoc(w, :fantasy_team),
       where: f.fantasy_league_id == ^league_id,
-      order_by: [desc: w.inserted_at]
+      order_by: [desc: w.process_at, asc: f.waiver_position]
   end
 
   def pending_waivers_for_player(add_player_id, league_id) do

--- a/web/models/waiver.ex
+++ b/web/models/waiver.ex
@@ -1,7 +1,9 @@
 defmodule Ex338.Waiver do
   use Ex338.Web, :model
 
-  @status_options ["pending", "unsuccessful", "successful"]
+  @status_options ["pending", "successful",
+                   "higher priority claim submitted",
+                   "invalid claim"]
 
   schema "waivers" do
     belongs_to :fantasy_team, Ex338.FantasyTeam

--- a/web/models/waiver.ex
+++ b/web/models/waiver.ex
@@ -31,9 +31,14 @@ defmodule Ex338.Waiver do
     |> cast(params, [:fantasy_team_id, :add_fantasy_player_id,
                      :drop_fantasy_player_id])
     |> validate_required([:fantasy_team_id])
+    |> set_datetime_to_process
     |> foreign_key_constraint(:fantasy_team_id)
     |> foreign_key_constraint(:drop_fantasy_player_id)
     |> foreign_key_constraint(:add_fantasy_player_id)
+  end
+
+  def set_datetime_to_process(changeset) do
+    put_change(changeset, :process_at, three_days_from_now)
   end
 
   def status_options, do: @status_options
@@ -43,5 +48,17 @@ defmodule Ex338.Waiver do
       join: f in assoc(w, :fantasy_team),
       where: f.fantasy_league_id == ^league_id,
       order_by: [desc: w.inserted_at]
+  end
+
+  defp three_days_from_now do
+    three_days = 86400*3
+    now = Ecto.DateTime.utc
+          |> Ecto.DateTime.to_erl
+          |> Calendar.DateTime.from_erl!("UTC")
+
+    now
+    |> Calendar.DateTime.add!(three_days)
+    |> Calendar.DateTime.to_erl
+    |> Ecto.DateTime.from_erl
   end
 end

--- a/web/router.ex
+++ b/web/router.ex
@@ -54,6 +54,7 @@ defmodule Ex338.Router do
     end
 
     resources "/draft_picks", DraftPickController, only: [:edit, :update]
+    resources "/waivers", WaiverController, only: [:edit, :update]
     resources "/fantasy_teams", FantasyTeamController,
       only: [:show, :edit, :update] do
         resources "/waivers", WaiverController, only: [:new, :create]

--- a/web/templates/waiver/admin_form.html.eex
+++ b/web/templates/waiver/admin_form.html.eex
@@ -1,0 +1,16 @@
+<%= form_for @changeset, @action, fn f -> %>
+  <%= if @changeset.action do %>
+    <div class="flash-error">
+      <p>Oops, something went wrong! Please check the errors below.</p>
+    </div>
+  <% end %>
+  <p><strong>
+  <div class="form-group">
+    <%= label f, :status, "Status of Waiver", class: "control-label" %>
+    <%= select f, :status, Ex338.Waiver.status_options %>
+  </div>
+
+  <%= link "Submit", to: @action, method: "post", data: [submit: "parent"],
+                    class: "btn" %>
+
+<% end %>

--- a/web/templates/waiver/admin_form.html.eex
+++ b/web/templates/waiver/admin_form.html.eex
@@ -10,7 +10,7 @@
     <%= select f, :status, Ex338.Waiver.status_options %>
   </div>
 
-  <%= link "Submit", to: @action, method: "post", data: [submit: "parent"],
-                    class: "btn" %>
-
+  <div class="form-group">
+    <%= submit "Submit" %>
+  </div>
 <% end %>

--- a/web/templates/waiver/edit.html.eex
+++ b/web/templates/waiver/edit.html.eex
@@ -1,0 +1,11 @@
+<h3>Process Waiver</h3>
+<p><strong>Fantasy Team: </strong><%= @waiver.fantasy_team.team_name %></p>
+
+<p><strong>Waiver Position: </strong><%= @waiver.fantasy_team.waiver_position %></p>
+</br>
+<p><strong>Add Fantasy Player: </strong>
+  <%= if @waiver.add_fantasy_player, do: @waiver.add_fantasy_player.player_name %></p>
+<p><strong>Drop Fantasy Player: </strong>
+  <%= if @waiver.drop_fantasy_player, do: @waiver.drop_fantasy_player.player_name %></p>
+<%= render "admin_form.html", changeset: @changeset, waiver: @waiver,
+                              action: waiver_path(@conn, :update, @waiver) %>

--- a/web/templates/waiver/index.html.eex
+++ b/web/templates/waiver/index.html.eex
@@ -5,8 +5,10 @@
 <section class="waivers-container">
   <div class="waivers-collection">
     <h5>Pending Approval</h5>
-    <%= render "table.html", waivers: @waivers, status: "pending" %>
+    <%= render "table.html", waivers: @waivers, status: "pending", 
+                             current_user: @current_user, conn: @conn %>
     <h5>Successful Claims</h5>
-    <%= render "table.html", waivers: @waivers, status: "successful" %>
+    <%= render "table.html", waivers: @waivers, status: "successful",
+                             current_user: @current_user, conn: @conn %>
   </div>
 </section>

--- a/web/templates/waiver/table.html.eex
+++ b/web/templates/waiver/table.html.eex
@@ -5,6 +5,11 @@
       <th>Fantasy Team</th>
       <th>Add Fantasy Player</th>
       <th>Drop Fantasy Player</th>
+      <%= if @current_user && @status == "pending" do %>
+        <%= if @current_user.admin == true do %>
+          <th>Admin Actions</th> 
+        <% end %>
+      <% end %>
     </tr>
   </thead>
   <tbody>
@@ -16,6 +21,11 @@
                      do: waiver.add_fantasy_player.player_name %></td>
         <td><%= if waiver.drop_fantasy_player, 
                      do: waiver.drop_fantasy_player.player_name %></td>
+        <%= if @current_user && @status == "pending" do %>
+          <%= if @current_user.admin == true do %>
+            <th><%= link "Process", to: waiver_path(@conn, :edit, waiver.id) %></th>
+          <% end %>
+        <% end %>
       </tr>
     <% end %>
      </tbody>

--- a/web/templates/waiver/table.html.eex
+++ b/web/templates/waiver/table.html.eex
@@ -2,9 +2,12 @@
   <thead>
     <tr>
       <th>Date</th>
-      <th>Fantasy Team</th>
-      <th>Add Fantasy Player</th>
-      <th>Drop Fantasy Player</th>
+      <th>Team</th>
+      <%= if @status == "pending" do %>
+        <th>Waiver Position</th>
+      <% end %>
+      <th>Add Player</th>
+      <th>Drop Player</th>
       <%= if @current_user && @status == "pending" do %>
         <%= if @current_user.admin == true do %>
           <th>Admin Actions</th> 
@@ -15,12 +18,21 @@
   <tbody>
     <%= for waiver <- @waivers, waiver.status == @status do %>
       <tr>
-        <td><%= pretty_date(waiver.inserted_at) %></td>
+        <td><%= short_date(waiver.inserted_at) %></td>
         <td><%= waiver.fantasy_team.team_name %></td>
-        <td><%= if waiver.add_fantasy_player, 
-                     do: waiver.add_fantasy_player.player_name %></td>
-        <td><%= if waiver.drop_fantasy_player, 
-                     do: waiver.drop_fantasy_player.player_name %></td>
+        <%= if @status == "pending" do %>
+          <td><%= waiver.fantasy_team.waiver_position %></td>
+        <% end %>
+        <%= if waiver.add_fantasy_player do %> 
+          <td><%= waiver.add_fantasy_player.player_name %> (<%= waiver.add_fantasy_player.sports_league.abbrev %>)</td>
+        <% else %>
+          <td></td>
+        <% end %>
+        <%= if waiver.drop_fantasy_player do %> 
+          <td><%= waiver.drop_fantasy_player.player_name %> (<%= waiver.drop_fantasy_player.sports_league.abbrev %>)</td>
+        <% else %>
+          <td></td>
+        <% end %>
         <%= if @current_user && @status == "pending" do %>
           <%= if @current_user.admin == true do %>
             <th><%= link "Process", to: waiver_path(@conn, :edit, waiver.id) %></th>

--- a/web/templates/waiver/table.html.eex
+++ b/web/templates/waiver/table.html.eex
@@ -1,7 +1,7 @@
 <table class="table waiver-table">
   <thead>
     <tr>
-      <th>Date</th>
+      <th>Effective Date/Time*</th>
       <th>Team</th>
       <%= if @status == "pending" do %>
         <th>Waiver Position</th>
@@ -18,7 +18,7 @@
   <tbody>
     <%= for waiver <- @waivers, waiver.status == @status do %>
       <tr>
-        <td><%= short_date(waiver.inserted_at) %></td>
+        <td><%= short_datetime_pst(waiver.process_at) %></td>
         <td><%= waiver.fantasy_team.team_name %></td>
         <%= if @status == "pending" do %>
           <td><%= waiver.fantasy_team.waiver_position %></td>
@@ -42,3 +42,4 @@
     <% end %>
      </tbody>
 </table>
+<p><strong>* All dates and times are in Pacific Standard Time (PST)/Pacific Daylight Time (PDT).</strong></p> 

--- a/web/views/view_helpers.ex
+++ b/web/views/view_helpers.ex
@@ -26,6 +26,14 @@ defmodule Ex338.ViewHelpers do
     |> strftime!("%b %e, %Y")
   end
 
+  def short_datetime_pst(date) do
+    date
+    |> Ecto.DateTime.to_erl
+    |> Calendar.DateTime.from_erl!("UTC")
+    |> Calendar.DateTime.shift_zone!("America/Los_Angeles")
+    |> strftime!("%b %e, %Y %l:%M %p")
+  end
+
   def sports_abbrevs(players_collection) do
     players_collection
     |> Enum.map(&(&1.league_abbrev))


### PR DESCRIPTION
Closes #55, #57, #73, #74, #75, and #76 

Adds form for admin to process waivers
When the status is updated, roster positions are created or marked "dropped", and waiver positions are updated across the league.