### PR TITLE
Validate an add or drop submitted with new waiver

### DIFF
--- a/test/controllers/waiver_controller_test.exs
+++ b/test/controllers/waiver_controller_test.exs
@@ -65,8 +65,8 @@ defmodule Ex338.WaiverControllerTest do
       player_a = insert(:fantasy_player)
       player_b = insert(:fantasy_player)
       insert(:roster_position, fantasy_player: player_a, fantasy_team: team)
-      attrs = %{fantasy_team_id: team.id, drop_fantasy_player_id: player_a.id,
-               add_fantasy_player_id: player_b.id}
+      attrs = %{drop_fantasy_player_id: player_a.id,
+                add_fantasy_player_id: player_b.id}
 
       conn = post conn, fantasy_team_waiver_path(conn, :create, team.id,
                                                  waiver: attrs)
@@ -84,7 +84,7 @@ defmodule Ex338.WaiverControllerTest do
       player_a = insert(:fantasy_player)
       _player_b = insert(:fantasy_player)
       insert(:roster_position, fantasy_player: player_a, fantasy_team: team)
-      invalid_attrs = %{fantasy_team_id: team.id, add_fantasy_player_id: -5}
+      invalid_attrs = %{drop_fantasy_player: "", add_fantasy_player_id: ""}
 
       conn = post conn, fantasy_team_waiver_path(conn, :create, team.id,
                                                  waiver: invalid_attrs)
@@ -98,8 +98,8 @@ defmodule Ex338.WaiverControllerTest do
       player_a = insert(:fantasy_player)
       player_b = insert(:fantasy_player)
       insert(:roster_position, fantasy_player: player_a, fantasy_team: team)
-      attrs = %{fantasy_team_id: team.id, drop_fantasy_player_id: player_a.id,
-               add_fantasy_player_id: player_b.id}
+      attrs = %{drop_fantasy_player_id: player_a.id,
+                add_fantasy_player_id: player_b.id}
 
       conn = post conn, fantasy_team_waiver_path(conn, :create, team.id,
                                                  waiver: attrs)

--- a/test/models/waiver_test.exs
+++ b/test/models/waiver_test.exs
@@ -3,30 +3,44 @@ defmodule Ex338.WaiverTest do
 
   alias Ex338.Waiver
 
-  @valid_attrs %{fantasy_team_id: 1}
+  @valid_attrs %{fantasy_team_id: 1, add_fantasy_player_id: 2}
   @invalid_attrs %{}
+  @invalid_new_attrs %{fantasy_team_id: 1}
 
   describe "changeset/2" do
-    test "changeset with valid attributes" do
+    test "valid with valid attributes" do
       changeset = Waiver.changeset(%Waiver{}, @valid_attrs)
       assert changeset.valid?
     end
 
-    test "changeset with invalid attributes" do
+    test "error with invalid attributes" do
       changeset = Waiver.changeset(%Waiver{}, @invalid_attrs)
       refute changeset.valid?
     end
   end
 
   describe "new_changeset/2" do
-    test "changeset with valid attributes" do
+    test "valid with valid attributes" do
       changeset = Waiver.new_changeset(%Waiver{}, @valid_attrs)
       assert changeset.valid?
     end
 
-    test "changeset with invalid attributes" do
+    test "error without a fantasy team or an add or a drop " do
       changeset = Waiver.new_changeset(%Waiver{}, @invalid_attrs)
+
       refute changeset.valid?
+      assert changeset.errors == [empty: {"Must submit an add or a drop", []},
+                                  fantasy_team_id: {"can't be blank", []}]
+      assert changeset.constraints ==
+        [%{constraint: "waivers_add_fantasy_player_id_fkey",
+          error: {"does not exist", []}, field: :add_fantasy_player_id,
+          match: :exact, type: :foreign_key},
+        %{constraint: "waivers_drop_fantasy_player_id_fkey",
+          error: {"does not exist", []}, field: :drop_fantasy_player_id,
+          match: :exact, type: :foreign_key},
+        %{constraint: "waivers_fantasy_team_id_fkey",
+          error: {"does not exist", []}, field: :fantasy_team_id,
+          match: :exact, type: :foreign_key}]
     end
   end
 

--- a/web/models/waiver.ex
+++ b/web/models/waiver.ex
@@ -33,6 +33,7 @@ defmodule Ex338.Waiver do
     |> cast(params, [:fantasy_team_id, :add_fantasy_player_id,
                      :drop_fantasy_player_id, :process_at])
     |> validate_required([:fantasy_team_id])
+    |> validate_add_or_drop
     |> foreign_key_constraint(:fantasy_team_id)
     |> foreign_key_constraint(:drop_fantasy_player_id)
     |> foreign_key_constraint(:add_fantasy_player_id)
@@ -53,4 +54,17 @@ defmodule Ex338.Waiver do
              w.add_fantasy_player_id == ^add_player_id,
       limit: 1
   end
+
+  defp validate_add_or_drop(waiver_changeset) do
+    add  = fetch_change(waiver_changeset, :add_fantasy_player_id)
+    drop = fetch_change(waiver_changeset, :drop_fantasy_player_id)
+
+   validate_add_or_drop(waiver_changeset, add, drop)
+  end
+
+  defp validate_add_or_drop(waiver_changeset, :error, :error) do
+    add_error(waiver_changeset, :empty, "Must submit an add or a drop")
+  end
+
+  defp validate_add_or_drop(waiver_changeset, _, _), do: waiver_changeset
 end


### PR DESCRIPTION
* When an owner submits a new waiver, an error is added to the changeset
  if both an add and drop are blank.
* Closes #83