### PR TITLE
Drop only waivers are processed immediately

### DIFF
--- a/web/controllers/waiver_controller.ex
+++ b/web/controllers/waiver_controller.ex
@@ -55,10 +55,7 @@ defmodule Ex338.WaiverController do
   def create(conn, %{"fantasy_team_id" => team_id, "waiver" => waiver_params}) do
     fantasy_team = conn.assigns.fantasy_team
 
-    result = fantasy_team
-             |> build_assoc(:waivers)
-             |> Waiver.new_changeset(waiver_params)
-             |> Repo.insert
+    result = Waiver.create_waiver(fantasy_team, waiver_params)
 
     case result do
       {:ok, waiver} ->

--- a/web/models/waiver.ex
+++ b/web/models/waiver.ex
@@ -59,6 +59,13 @@ defmodule Ex338.Waiver do
       limit: 1
   end
 
+  def create_waiver(fantasy_team, waiver_params) do
+    fantasy_team
+    |> build_assoc(:waivers)
+    |> new_changeset(waiver_params)
+    |> Repo.insert
+  end
+
   def update_waiver(waiver, params) do
     waiver
     |> WaiverAdmin.process_waiver(params)


### PR DESCRIPTION
Since there is no waiting period, a drop only is processed immediately
The waiver status is "successful" and the roster position is "dropped"
Closes #81