### PR TITLE
Hide the link to update when wait period ends

### DIFF
--- a/web/templates/waiver/pending_table.html.eex
+++ b/web/templates/waiver/pending_table.html.eex
@@ -26,7 +26,7 @@
           <td></td>
         <% end %>
         <td>
-        <%= if owner?(@current_user, waiver) || @current_user.admin do %>
+        <%= if waiver.process_at > Ecto.DateTime.utc && (owner?(@current_user, waiver) || @current_user.admin) do %>
           <%= link "Update", to: waiver_path(@conn, :edit, waiver) %>
         <% end %>
         <%= if @current_user && @current_user.admin == true do %>


### PR DESCRIPTION
* Hide the link to update the waiver after the wait period ends
* According to rules updates cease after the wait period ends
* Initial effort to resolve issue #120