### PR TITLE
Validate open position for add only waiver

### DIFF
--- a/test/models/roster_position_repo_test.exs
+++ b/test/models/roster_position_repo_test.exs
@@ -43,4 +43,15 @@ defmodule Ex338.RosterPositionRepoTest do
       assert result.released_at == Ecto.DateTime.utc
     end
   end
+
+  describe "count_positions_for_team" do
+    test "counts the active positions on a fantasy team" do
+      team = insert(:fantasy_team)
+      insert_list(2, :roster_position, fantasy_team: team, status: "active")
+
+      count = RosterPosition |> RosterPosition.count_positions_for_team(team.id)
+
+      assert count == 2
+    end
+  end
 end

--- a/web/models/roster_position.ex
+++ b/web/models/roster_position.ex
@@ -3,7 +3,7 @@ defmodule Ex338.RosterPosition do
 
   use Ex338.Web, :model
 
-  alias Ex338.{FantasyTeam, FantasyPlayer}
+  alias Ex338.{FantasyTeam, FantasyPlayer, Repo}
 
   @default_position ["Unassigned"]
 
@@ -60,5 +60,14 @@ defmodule Ex338.RosterPosition do
       where: r.fantasy_player_id == ^player_id,
       update: [set: [released_at: ^released_at]],
       update: [set: [status:      ^status]]
+  end
+
+  def count_positions_for_team(query, team_id) do
+    query =
+      from r in query,
+        where: r.fantasy_team_id == ^team_id,
+        where: r.status == "active"
+
+    Repo.aggregate(query, :count, :id)
   end
 end


### PR DESCRIPTION
* When an owner submits an add only waiver, he must have an open position
* Validates there is an open position on the roster for add only waiver
* Closes #122