### PR TITLE
Update sort_most_recent/1 to fix bug

### DIFF
--- a/test/views/waiver_view_test.exs
+++ b/test/views/waiver_view_test.exs
@@ -11,7 +11,7 @@ defmodule Ex338.WaiverViewTest do
           )},
         %{fantasy_team: "c",
           process_at: Ecto.DateTime.cast!(
-            %{day: 3, hour: 14, min: 0, month: 4, sec: 0, year: 2010}
+            %{day: 3, hour: 14, min: 0, month: 5, sec: 0, year: 2010}
           )},
         %{fantasy_team: "b",
           process_at: Ecto.DateTime.cast!(

--- a/web/views/waiver_view.ex
+++ b/web/views/waiver_view.ex
@@ -1,11 +1,20 @@
 defmodule Ex338.WaiverView do
   use Ex338.Web, :view
-  def sort_most_recent(query) do
-    Enum.sort(query, &(&1.process_at >= &2.process_at))
-  end
 
   def after_now?(date_time) do
     case Ecto.DateTime.compare(date_time, Ecto.DateTime.utc) do
+      :gt -> true
+      :eq -> true
+      :lt -> false
+    end
+  end
+
+  def sort_most_recent(query) do
+    Enum.sort(query, &(before_other_date?(&1.process_at, &2.process_at)))
+  end
+
+  defp before_other_date?(date1, date2) do
+    case Ecto.DateTime.compare(date1, date2) do
       :gt -> true
       :eq -> true
       :lt -> false


### PR DESCRIPTION
* Dates were compared using >= operator which does work properly
* Updated formula to use Ecto.DateTime.compare/2
* Closes #143