### PR TITLE
Update fantasy team table to display rank & points

### DIFF
--- a/lib/roster_admin.ex
+++ b/lib/roster_admin.ex
@@ -79,7 +79,7 @@ defmodule Ex338.RosterAdmin do
       Map.put(map, position, %{
         fantasy_player: %{player_name: "",
           sports_league: %{abbrev: ""},
-          championship_results: [%{points: "", rank: ""}]
+          championship_results: []
         }
       })
     end

--- a/lib/roster_admin.ex
+++ b/lib/roster_admin.ex
@@ -66,8 +66,7 @@ defmodule Ex338.RosterAdmin do
   defp format_query_for_merge(roster_positions) do
     Enum.reduce roster_positions, %{}, fn(p, acc) ->
       Map.put(acc, p.position, %{
-        fantasy_player: %{player_name: p.fantasy_player.player_name,
-          sports_league: %{abbrev: p.fantasy_player.sports_league.abbrev}}})
+        fantasy_player: p.fantasy_player})
     end
   end
 
@@ -79,7 +78,10 @@ defmodule Ex338.RosterAdmin do
     Enum.reduce RosterPosition.positions, %{}, fn(position, map) ->
       Map.put(map, position, %{
         fantasy_player: %{player_name: "",
-          sports_league: %{abbrev: ""}}})
+          sports_league: %{abbrev: ""},
+          championship_results: [%{points: "", rank: ""}]
+        }
+      })
     end
   end
 

--- a/test/lib/roster_admin_test.exs
+++ b/test/lib/roster_admin_test.exs
@@ -1,6 +1,6 @@
 defmodule Ex338.RosterAdminTest do
   use Ex338.ModelCase
-  alias Ex338.{RosterAdmin, FantasyTeam}
+  alias Ex338.{RosterAdmin, FantasyTeam, RosterPosition}
 
   describe "add_open_positions_to_teams/1" do
     test "adds position for any position without a player in a collection" do
@@ -11,8 +11,9 @@ defmodule Ex338.RosterAdminTest do
       insert(:filled_roster_position, position: "CFB",
                                       fantasy_team: team_b)
 
+      active_positions = RosterPosition.active_positions(RosterPosition)
       [a, b] = FantasyTeam
-               |> preload(roster_positions: [fantasy_player: :sports_league])
+               |> preload(roster_positions: ^active_positions)
                |> FantasyTeam.alphabetical
                |> Repo.all
                |> RosterAdmin.add_open_positions_to_teams
@@ -32,9 +33,9 @@ defmodule Ex338.RosterAdminTest do
       insert(:filled_roster_position, position: "CFB",
                                       fantasy_team: team_a)
 
+      active_positions = RosterPosition.active_positions(RosterPosition)
       team = FantasyTeam
-            |> preload([[roster_positions: [fantasy_player: :sports_league]],
-                        [owners: :user], :fantasy_league])
+            |> preload([roster_positions: ^active_positions])
             |> Repo.get!(team_a.id)
             |> RosterAdmin.add_open_positions_to_team
 

--- a/test/models/fantasy_player_repo_test.exs
+++ b/test/models/fantasy_player_repo_test.exs
@@ -93,4 +93,20 @@ defmodule Ex338.FantasyPlayerRepoTest do
       assert date == championship.waiver_deadline_at
     end
   end
+
+  describe "preload_overall_results" do
+    test "preloads all overall championship results" do
+      player  = insert(:fantasy_player)
+      overall = insert(:championship, category: "overall")
+      event   = insert(:championship, category: "event")
+      insert(:championship_result, fantasy_player: player, championship: overall)
+      insert(:championship_result, fantasy_player: player, championship: event)
+
+      result = FantasyPlayer
+               |> FantasyPlayer.preload_overall_results
+               |> Repo.one
+
+      assert Enum.count(result.championship_results) == 1
+    end
+  end
 end

--- a/test/models/roster_position_repo_test.exs
+++ b/test/models/roster_position_repo_test.exs
@@ -3,7 +3,7 @@ defmodule Ex338.RosterPositionRepoTest do
   alias Ex338.{RosterPosition}
 
   describe "active_positions/1" do
-    test "only returns active roster positions" do
+    test "only returns active roster positions with championship results" do
       player_a = insert(:fantasy_player)
       player_b = insert(:fantasy_player)
       player_c = insert(:fantasy_player)
@@ -14,10 +14,17 @@ defmodule Ex338.RosterPositionRepoTest do
                                status: "dropped")
       insert(:roster_position, fantasy_team: team, fantasy_player: player_c,
                                status: "traded")
+      championship = insert(:championship, category: "overall")
+      insert(:championship_result, fantasy_player: player_a,
+                                   championship: championship)
 
-      query = RosterPosition.active_positions(RosterPosition)
+      results = RosterPosition
+                |> RosterPosition.active_positions
+                |> Repo.all
+      result  = List.first(results)
 
-      assert Repo.aggregate(query, :count, :id) == 1
+      assert Enum.count(results) == 1
+      assert Enum.count(result.fantasy_player.championship_results) == 1
     end
   end
 

--- a/test/views/fantasy_team_view_test.exs
+++ b/test/views/fantasy_team_view_test.exs
@@ -21,4 +21,20 @@ defmodule Ex338.FantasyTeamViewTest do
       assert results == ["CBB"] ++ RosterPosition.flex_positions
     end
   end
+
+  describe "display_results/2" do
+    test "returns values under championship result keys" do
+      position = %{fantasy_player: %{championship_results: [%{rank: 1, points: 8}]}}
+
+      assert FantasyTeamView.display_results(position, :rank) == 1
+      assert FantasyTeamView.display_results(position, :points) == 8
+    end
+
+    test "returns an empty string if no championship results" do
+      position = %{fantasy_player: %{championship_results: []}}
+
+      assert FantasyTeamView.display_results(position, :rank) == ""
+      assert FantasyTeamView.display_results(position, :points) == ""
+    end
+  end
 end

--- a/web/models/fantasy_player.ex
+++ b/web/models/fantasy_player.ex
@@ -68,4 +68,12 @@ defmodule Ex338.FantasyPlayer do
     select: %{player_name: p.player_name, league_abbrev: s.abbrev, id: p.id},
     order_by: [s.abbrev, p.player_name]
   end
+
+  def preload_overall_results(query) do
+    overall_results = ChampionshipResult.only_overall(ChampionshipResult)
+
+    from p in query,
+      preload: [championship_results: ^overall_results],
+      preload: [:sports_league]
+  end
 end

--- a/web/models/roster_position.ex
+++ b/web/models/roster_position.ex
@@ -49,9 +49,12 @@ defmodule Ex338.RosterPosition do
   def status_options, do: @status_options
 
   def active_positions(query) do
+    players_with_results = FantasyPlayer
+                           |> FantasyPlayer.preload_overall_results
+
     from r in query,
       where: r.status == "active",
-      preload: [fantasy_player: :sports_league]
+      preload: [fantasy_player: ^players_with_results]
   end
 
   def update_position_status(query, team_id, player_id, released_at, status) do

--- a/web/templates/fantasy_team/table.html.eex
+++ b/web/templates/fantasy_team/table.html.eex
@@ -3,29 +3,18 @@
     <tr>
       <th>Position</th>
       <th>Fantasy Player</th>
-      <th>Sports League</th>
+      <th>League</th>
     </tr>
   </thead>
   <tbody>
     <%= for roster_position <- sort_by_position(
           primary_positions(@fantasy_team.roster_positions)) do %>
-      <tr>
-        <td><%= roster_position.position %></td>
-        <td><%= if roster_position.fantasy_player, 
-                  do: roster_position.fantasy_player.player_name %></td>
-        <td><%= if roster_position.fantasy_player,
-                  do: roster_position.fantasy_player.sports_league.abbrev %></td>
-      </tr>
+      <%= render "table_row.html", roster_position: roster_position %>
     <% end %>
+
     <%= for roster_position <- sort_by_position(
           flex_and_unassigned_positions(@fantasy_team.roster_positions)) do %>
-      <tr>
-        <td><%= roster_position.position %></td>
-        <td><%= if roster_position.fantasy_player,
-                  do: roster_position.fantasy_player.player_name %></td>
-        <td><%= if roster_position.fantasy_player,
-                  do: roster_position.fantasy_player.sports_league.abbrev %></td>
-      </tr>
+      <%= render "table_row.html", roster_position: roster_position %>
     <% end %>
   </tbody>
 </table>

--- a/web/templates/fantasy_team/table.html.eex
+++ b/web/templates/fantasy_team/table.html.eex
@@ -4,6 +4,7 @@
       <th>Position</th>
       <th>Fantasy Player</th>
       <th>League</th>
+      <th>Rank (Points)</th>
     </tr>
   </thead>
   <tbody>

--- a/web/templates/fantasy_team/table_row.html.eex
+++ b/web/templates/fantasy_team/table_row.html.eex
@@ -1,0 +1,11 @@
+<tr>
+  <td><%= @roster_position.position %></td>
+  <td>
+    <%= if @roster_position.fantasy_player, 
+      do: @roster_position.fantasy_player.player_name %>
+  </td>
+  <td>
+    <%= if @roster_position.fantasy_player,
+      do: @roster_position.fantasy_player.sports_league.abbrev %>
+  </td>
+</tr>

--- a/web/templates/fantasy_team/table_row.html.eex
+++ b/web/templates/fantasy_team/table_row.html.eex
@@ -8,4 +8,8 @@
     <%= if @roster_position.fantasy_player,
       do: @roster_position.fantasy_player.sports_league.abbrev %>
   </td>
+  <td><%= if @roster_position.fantasy_player.championship_results !== [] do %>
+      <%= display_results(@roster_position, :rank) %>
+      (<%= display_results(@roster_position, :points) %>)
+      <% end %>
 </tr>

--- a/web/views/fantasy_team_view.ex
+++ b/web/views/fantasy_team_view.ex
@@ -11,4 +11,18 @@ defmodule Ex338.FantasyTeamView do
   def position_selections(r) do
     [r.model.fantasy_player.sports_league.abbrev] ++ RosterPosition.flex_positions
   end
+
+  def display_results(roster_position, key) do
+    roster_position.fantasy_player.championship_results
+    |> List.first
+    |> display_value(key)
+  end
+
+  defp display_value(nil, _) do
+    ""
+  end
+
+  defp display_value(result, key) do
+    Map.get(result, key)
+  end
 end


### PR DESCRIPTION
* Update table to display championship result rank and points
* Refactor fantasy team table to extract row
* Included championship results in RosterAdmin.add_open_positions_to_teams/1
* Include championship results in active position query
* Closes #156