### PR TITLE
Remove avail players from waiver form after deadline

### DIFF
--- a/test/models/championship_repo_test.exs
+++ b/test/models/championship_repo_test.exs
@@ -17,9 +17,10 @@ defmodule Ex338.ChampionshipRepoTest do
         )
       )
 
-      query = Championship
-              |> Championship.earliest_first
-              |> select([c], c.title)
+      query =
+        Championship
+        |> Championship.earliest_first
+        |> select([c], c.title)
 
       assert Repo.all(query) == ~w(B A)
     end
@@ -47,11 +48,39 @@ defmodule Ex338.ChampionshipRepoTest do
         championship_at:    CalendarAssistant.days_from_now(19)
       )
 
-      query = Championship
-              |> Championship.future_championships
-              |> select([c], c.title)
+      query =
+        Championship
+        |> Championship.future_championships
+        |> select([c], c.title)
 
       assert Repo.all(query) == ~w(C B)
+    end
+  end
+
+  describe "all_with_overall_waivers_open/1" do
+    test "returns all overall championships with waiver deadline in future" do
+      _prev_champ = insert(:championship,
+        title: "A",
+        category: "overall",
+        waiver_deadline_at: CalendarAssistant.days_from_now(-1)
+      )
+      _open_champ = insert(:championship,
+        title: "C",
+        category: "overall",
+        waiver_deadline_at: CalendarAssistant.days_from_now(1)
+      )
+      _event = insert(:championship,
+        title: "B",
+        category: "event",
+        waiver_deadline_at: CalendarAssistant.days_from_now(3)
+      )
+
+      query =
+        Championship
+        |> Championship.all_with_overall_waivers_open
+        |> select([c], c.title)
+
+      assert Repo.all(query) == ~w(C)
     end
   end
 
@@ -61,12 +90,15 @@ defmodule Ex338.ChampionshipRepoTest do
       league = insert(:sports_league)
       championship = insert(:championship, sports_league: league)
       player = insert(:fantasy_player, sports_league: league)
-      champ_result = insert(:championship_result, championship: championship,
-                                                  fantasy_player: player)
+      champ_result = insert(:championship_result,
+       championship: championship,
+       fantasy_player: player
+      )
 
-      result = Championship
-               |> Championship.preload_assocs
-               |> Repo.one
+      result =
+        Championship
+        |> Championship.preload_assocs
+        |> Repo.one
 
       assert result.sports_league.id == league.id
       assert Enum.at(result.championship_results, 0).id == champ_result.id
@@ -87,7 +119,7 @@ defmodule Ex338.ChampionshipRepoTest do
     test "returns all championships" do
       insert_list(3, :championship)
 
-      result = Championship |> Championship.get_all
+      result = Championship.get_all(Championship)
 
       assert Enum.count(result) == 3
     end

--- a/test/models/fantasy_player_repo_test.exs
+++ b/test/models/fantasy_player_repo_test.exs
@@ -28,20 +28,30 @@ defmodule Ex338.FantasyPlayerRepoTest do
 
   describe "get_available_players/1" do
     test "returns available players in league" do
-      league_a = insert(:fantasy_league)
-      league_b = insert(:fantasy_league)
-      team_a = insert(:fantasy_team, fantasy_league: league_a)
-      team_b = insert(:fantasy_team, fantasy_league: league_b)
-      player_a = insert(:fantasy_player)
-      player_b = insert(:fantasy_player)
-      player_c = insert(:fantasy_player)
-      _player_d = insert(:fantasy_player)
+      league_a = insert(:sports_league, abbrev: "A")
+      league_b = insert(:sports_league, abbrev: "B")
+      league_c = insert(:sports_league, abbrev: "C")
+      insert(:championship, sports_league: league_a,
+        waiver_deadline_at: CalendarAssistant.days_from_now(5))
+      insert(:championship, sports_league: league_b,
+        waiver_deadline_at: CalendarAssistant.days_from_now(5))
+      insert(:championship, sports_league: league_b,
+        waiver_deadline_at: CalendarAssistant.days_from_now(-5))
+      f_league_a = insert(:fantasy_league)
+      f_league_b = insert(:fantasy_league)
+      team_a = insert(:fantasy_team, fantasy_league: f_league_a)
+      team_b = insert(:fantasy_team, fantasy_league: f_league_b)
+      player_a = insert(:fantasy_player, sports_league: league_a)
+      player_b = insert(:fantasy_player, sports_league: league_a)
+      player_c = insert(:fantasy_player, sports_league: league_b)
+      _player_d = insert(:fantasy_player, sports_league: league_b)
+      _player_e = insert(:fantasy_player, sports_league: league_c)
       insert(:roster_position, fantasy_team: team_a, fantasy_player: player_a)
       insert(:roster_position, fantasy_team: team_b, fantasy_player: player_b)
       insert(:roster_position, fantasy_team: team_a, fantasy_player: player_c,
                                status: "dropped")
 
-      result = FantasyPlayer.get_available_players(league_a.id)
+      result = FantasyPlayer.get_available_players(f_league_a.id)
 
       assert Enum.count(result) == 3
     end
@@ -51,10 +61,18 @@ defmodule Ex338.FantasyPlayerRepoTest do
     test "returns unowned players in a league for select option" do
       league_a = insert(:sports_league, abbrev: "A")
       league_b = insert(:sports_league, abbrev: "B")
+      league_c = insert(:sports_league, abbrev: "C")
+      insert(:championship, sports_league: league_a,
+        waiver_deadline_at: CalendarAssistant.days_from_now(5))
+      insert(:championship, sports_league: league_b,
+        waiver_deadline_at: CalendarAssistant.days_from_now(5))
+      insert(:championship, sports_league: league_b,
+        waiver_deadline_at: CalendarAssistant.days_from_now(-5))
       player_a = insert(:fantasy_player, sports_league: league_a)
       player_b = insert(:fantasy_player, sports_league: league_a)
       player_c = insert(:fantasy_player, sports_league: league_b)
       player_d = insert(:fantasy_player, sports_league: league_b)
+      _player_e = insert(:fantasy_player, sports_league: league_c)
       f_league_a = insert(:fantasy_league)
       f_league_b = insert(:fantasy_league)
       team_a = insert(:fantasy_team, fantasy_league: f_league_a)

--- a/web/models/championship.ex
+++ b/web/models/championship.ex
@@ -57,6 +57,12 @@ defmodule Ex338.Championship do
       order_by: c.championship_at
   end
 
+  def all_with_overall_waivers_open(query) do
+    from c in query,
+      where: c.waiver_deadline_at > ago(0, "second"),
+      where: c.category == "overall"
+  end
+
   def preload_assocs(query) do
     results = ChampionshipResult.get_assocs_and_order_results(ChampionshipResult)
 

--- a/web/models/fantasy_player.ex
+++ b/web/models/fantasy_player.ex
@@ -65,6 +65,9 @@ defmodule Ex338.FantasyPlayer do
       t.fantasy_league_id == ^fantasy_league_id,
     right_join: p in assoc(r, :fantasy_player),
     inner_join: s in assoc(p, :sports_league),
+    inner_join: c in subquery(
+      Championship.all_with_overall_waivers_open(Championship)),
+     on: c.sports_league_id == s.id,
     where: is_nil(r.fantasy_team_id),
     select: %{player_name: p.player_name, league_abbrev: s.abbrev, id: p.id},
     order_by: [s.abbrev, p.player_name]


### PR DESCRIPTION
* After the overall deadline passes, owners can't claim players
* Update removes those players from the select options for new waivers
* Removed from overall list and sports league filter
* Did not remove if just on hold until event championship is over
* Closes #131