### PR TITLE
Add form for commish to send league-wide emails

### DIFF
--- a/lib/commish_email.ex
+++ b/lib/commish_email.ex
@@ -1,0 +1,19 @@
+defmodule Ex338.CommishEmail do
+  @moduledoc false
+  alias Ex338.{Owner, User, EmailTemplate, Mailer, Repo}
+
+  def send_email_to_leagues(leagues, subject, message) do
+    email_info =
+      %{
+        to: Owner.get_leagues_email_addresses(leagues),
+        cc: Repo.all(User.admin_emails),
+        from: {"338 Commish", "no-reply@338admin.com"},
+        subject: subject,
+        message: message
+      }
+
+    email_info
+    |> EmailTemplate.plain_text
+    |> Mailer.deliver
+  end
+end

--- a/test/controllers/commish_email_controller_test.exs
+++ b/test/controllers/commish_email_controller_test.exs
@@ -1,0 +1,88 @@
+defmodule Ex338.CommishEmailControllerTest do
+  use Ex338.ConnCase
+  import Swoosh.TestAssertions
+  alias Ex338.{User, EmailTemplate}
+
+  setup %{conn: conn} do
+    user = %User{name: "test", email: "test@example.com", id: 1}
+    {:ok, conn: assign(conn, :current_user, user), user: user}
+  end
+
+  describe "new/1" do
+    test "renders a form to send an email", %{conn: conn} do
+      conn = put_in(conn.assigns.current_user.admin, true)
+      insert(:fantasy_league)
+
+      conn = get conn, commish_email_path(conn, :new)
+
+      assert html_response(conn, 200) =~ ~r/Send Email to League/
+    end
+
+    test "redirects to root if user is not owner", %{conn: conn} do
+      insert(:fantasy_league)
+
+      conn = get conn, commish_email_path(conn, :new)
+
+      assert html_response(conn, 302) =~ ~r/redirected/
+    end
+  end
+
+  describe "create/2" do
+    test "send email with text to owners in multiple leagues", %{conn: conn} do
+      conn = put_in(conn.assigns.current_user.admin, true)
+      other_user = insert_user
+      league = insert(:fantasy_league)
+      team = insert(:fantasy_team, fantasy_league: league)
+      insert(:owner, fantasy_team: team, user: other_user)
+      subject = "Announcement"
+      message = "Here is the latest info!"
+
+      email_info = %{
+        to: [{other_user.name, other_user.email}],
+        cc: [],
+        from: {"338 Commish", "no-reply@338admin.com"},
+        subject: subject,
+        message: message
+      }
+
+      attrs = %{
+        leagues: [league.id],
+        subject: subject,
+        message: message
+      }
+
+      conn = post conn, commish_email_path(conn, :create, commish_email: attrs)
+
+      assert html_response(conn, 302) =~ ~r/redirected/
+      assert_email_sent EmailTemplate.plain_text(email_info)
+    end
+
+    test "redirects to root if user is not admin", %{conn: conn} do
+      other_user = insert_user
+      league = insert(:fantasy_league)
+      team = insert(:fantasy_team, fantasy_league: league)
+      insert(:owner, fantasy_team: team, user: other_user)
+      subject = "Announcement"
+      message = "Here is the latest info!"
+
+      email_info = %{
+        to: [{other_user.name, other_user.email}],
+        cc: [],
+        from: {"338 Commish", "no-reply@338admin.com"},
+        subject: subject,
+        message: message
+      }
+
+      attrs = %{
+        leagues: [league.id],
+        subject: subject,
+        message: message
+      }
+
+      conn = post conn, commish_email_path(conn, :create, commish_email: attrs)
+
+      assert html_response(conn, 302) =~ ~r/redirected/
+      assert_no_email_sent
+    end
+  end
+end

--- a/test/lib/commish_email_test.exs
+++ b/test/lib/commish_email_test.exs
@@ -1,0 +1,33 @@
+defmodule Ex338.CommishEmailTest do
+  use Ex338.ModelCase
+  import Swoosh.TestAssertions
+  alias Ex338.{EmailTemplate, CommishEmail}
+
+  describe "send_email_to_leagues/3" do
+    test "sends an email to owners of a list of leagues" do
+      admin_user = insert_admin
+      other_user = insert_user
+      league = insert(:fantasy_league)
+      team = insert(:fantasy_team, fantasy_league: league)
+      insert(:owner, fantasy_team: team, user: other_user)
+      subject = "Announcement"
+      message = "Here is the latest info!"
+
+      email_info = %{
+        to: [{other_user.name, other_user.email}],
+        cc: [{admin_user.name, admin_user.email}],
+        from: {"338 Commish", "no-reply@338admin.com"},
+        subject: subject,
+        message: message
+      }
+
+      CommishEmail.send_email_to_leagues(
+        [league.id],
+        subject,
+        message
+      )
+
+      assert_email_sent EmailTemplate.plain_text(email_info)
+    end
+  end
+end

--- a/test/models/owner_repo_test.exs
+++ b/test/models/owner_repo_test.exs
@@ -40,4 +40,46 @@ defmodule Ex338.OwnerRepoTest do
       assert Repo.all(query) == [{user_a.name, user_a.email}]
     end
   end
+
+  describe "get_email_recipients/2" do
+    test "return email addresses for a league" do
+      league_a = insert(:fantasy_league)
+      league_b = insert(:fantasy_league)
+      team_a = insert(:fantasy_team, team_name: "A", fantasy_league: league_a)
+      team_b = insert(:fantasy_team, team_name: "B", fantasy_league: league_b)
+      user_a = insert_user
+      user_b = insert_user
+      insert(:owner, fantasy_team: team_a, user: user_a)
+      insert(:owner, fantasy_team: team_b, user: user_b)
+
+
+      result = Owner |> Owner.get_email_recipients_for_league(league_a.id)
+
+      assert result == [{user_a.name, user_a.email}]
+    end
+  end
+
+  describe "get_leagues_email_recipients/1" do
+    test "return email addresses for multiple leagues" do
+      league_a = insert(:fantasy_league)
+      league_b = insert(:fantasy_league)
+      team_a = insert(:fantasy_team, team_name: "A", fantasy_league: league_a)
+      team_b = insert(:fantasy_team, team_name: "B", fantasy_league: league_b)
+      user_a = insert_user
+      user_b = insert_user
+      _user_c = insert_user
+      insert(:owner, fantasy_team: team_a, user: user_a)
+      insert(:owner, fantasy_team: team_b, user: user_b)
+
+      result = Owner.get_leagues_email_addresses([
+        league_a.id,
+        league_b.id
+      ])
+
+      assert result == [
+        {user_b.name, user_b.email},
+        {user_a.name, user_a.email}
+      ]
+    end
+  end
 end

--- a/test/views/commish_email_view_test.exs
+++ b/test/views/commish_email_view_test.exs
@@ -1,0 +1,17 @@
+defmodule Ex338.CommishEmailViewTest do
+  use Ex338.ConnCase, async: true
+  alias Ex338.{CommishEmailView}
+
+  describe "format_leagues_for_select/1" do
+    test "formats leagues for multiple select in form" do
+      leagues = [
+        %{fantasy_league_name: "Div A", id: 1},
+        %{fantasy_league_name: "Div B", id: 2}
+      ]
+
+      results = CommishEmailView.format_leagues_for_select(leagues)
+
+      assert results == ["Div A": 1, "Div B": 2]
+    end
+  end
+end

--- a/web/controllers/commish_email_controller.ex
+++ b/web/controllers/commish_email_controller.ex
@@ -1,0 +1,29 @@
+defmodule Ex338.CommishEmailController do
+  use Ex338.Web, :controller
+  alias Ex338.{Repo, FantasyLeague, CommishEmail}
+
+  def new(conn, _params) do
+    render(conn, "new.html",
+      fantasy_leagues: Repo.all(FantasyLeague)
+    )
+  end
+
+  def create(conn, %{"commish_email" => %{
+    "leagues" => leagues,
+    "subject" => subject,
+    "message" => message
+  }}) do
+    result = CommishEmail.send_email_to_leagues(leagues, subject, message)
+
+    case result do
+      {:ok, _result} ->
+        conn
+        |> put_flash(:info, "Email sent successfully")
+        |> redirect(to: commish_email_path(conn, :new))
+      {:error, _reason} ->
+        conn
+        |> put_flash(:error, "There was an error while sending the email")
+        |> redirect(to: commish_email_path(conn, :new))
+    end
+  end
+end

--- a/web/emails/email_template.ex
+++ b/web/emails/email_template.ex
@@ -1,0 +1,21 @@
+defmodule Ex338.EmailTemplate do
+  @moduledoc false
+
+  import Swoosh.Email
+
+  def plain_text(%{
+    to: recipients,
+    cc: cc,
+    from: from,
+    subject: subject,
+    message: message
+  }) do
+
+    new
+    |> to(recipients)
+    |> cc(cc)
+    |> from(from)
+    |> subject(subject)
+    |> text_body(message)
+  end
+end

--- a/web/models/owner.ex
+++ b/web/models/owner.ex
@@ -1,7 +1,7 @@
 defmodule Ex338.Owner do
   use Ex338.Web, :model
 
-  alias Ex338.{Owner}
+  alias Ex338.{Owner, Repo}
 
   schema "owners" do
     belongs_to :fantasy_team, Ex338.FantasyTeam
@@ -24,6 +24,19 @@ defmodule Ex338.Owner do
       join: f in assoc(o, :fantasy_team),
       where: f.fantasy_league_id == ^league_id,
       order_by: [asc: f.team_name]
+  end
+
+  def get_leagues_email_addresses(leagues) do
+    Enum.reduce leagues, [], fn(league, acc) ->
+      addresses = get_email_recipients_for_league(Owner, league)
+      addresses ++ acc
+    end
+  end
+
+  def get_email_recipients_for_league(query, league_id) do
+    query
+    |> email_recipients_for_league(league_id)
+    |> Repo.all
   end
 
   def email_recipients_for_league(query, league_id) do

--- a/web/router.ex
+++ b/web/router.ex
@@ -69,6 +69,7 @@ defmodule Ex338.Router do
   scope "/", Ex338 do
     pipe_through [:protected, :admin]
     resources "/waiver_admin", WaiverAdminController, only: [:edit, :update]
+    resources "/commish_email", CommishEmailController, only: [:new, :create]
   end
 
   scope "/admin", ExAdmin do

--- a/web/templates/commish_email/form.html.eex
+++ b/web/templates/commish_email/form.html.eex
@@ -1,0 +1,21 @@
+<%= form_for @conn, @action, [as: :commish_email], fn f -> %>
+<div class="form-group">
+  <%= label f, :select_leagues_to_email, class: "control-label" %>
+  <%= multiple_select f, :leagues, format_leagues_for_select(@fantasy_leagues),
+        class: "form-control", required: "required" %>
+</div>
+
+<div class="form-group">
+  <%= label f, :subject, class: "control-label" %>
+  <%= text_input f, :subject, class: "form-control", required: "required" %>
+</div>
+
+<div class="form-group">
+  <%= label f, :message, class: "control-label" %>
+  <%= textarea f, :message, class: "form-control", rows: 6, required: "required" %>
+</div>
+
+<div class="form-group">
+  <%= submit "Send" %>
+</div>
+<% end %>

--- a/web/templates/commish_email/new.html.eex
+++ b/web/templates/commish_email/new.html.eex
@@ -1,0 +1,5 @@
+<h2>Send Email to League</h2>
+
+<%= render "form.html", conn: @conn,
+                        action: commish_email_path(@conn, :create),
+                        fantasy_leagues: @fantasy_leagues %>

--- a/web/templates/layout/header.html.eex
+++ b/web/templates/layout/header.html.eex
@@ -38,8 +38,14 @@
         </li>
         <%= if @current_user do %>
           <%= if @current_user.admin == true do %>
-            <li class="nav-link"><%= link "Admin", to: admin_path(@conn, :dashboard) %></li>
-            <li class="nav-link"><%= Ex338.Coherence.ViewHelpers.invitation_link(@conn) %></li>
+            <li id="js-navigation-more" class="nav-link more">
+              <a href="javascript:void(0)">Commish Tools</a>
+              <ul class="submenu">
+                <li class="nav-link"><%= link "Admin", to: admin_path(@conn, :dashboard) %></li>
+                <li class="nav-link"><%= link "League Email", to: commish_email_path(@conn, :new) %></li>
+                <li class="nav-link"><%= Ex338.Coherence.ViewHelpers.invitation_link(@conn) %></li>
+              </ul>
+            </li>
           <% end %>
         <% end %>
         <%= if @current_user do %>

--- a/web/views/commish_email_view.ex
+++ b/web/views/commish_email_view.ex
@@ -1,0 +1,10 @@
+defmodule Ex338.CommishEmailView do
+  use Ex338.Web, :view
+
+  def format_leagues_for_select(leagues) do
+    Enum.map leagues, fn(league) ->
+      name = String.to_atom(league.fantasy_league_name)
+      {name, league.id}
+    end
+  end
+end


### PR DESCRIPTION
* The commish sends reminder emails out to the league
* He'd like to be able to send those out through the site
* The email can just be plain text
* He has the ability to select which league to send it to
* Updated navbar with Commish Tools drop down
* Closes issue #145