### PR TITLE
Add ranking to standings page

### DIFF
--- a/test/views/fantasy_league_view_test.exs
+++ b/test/views/fantasy_league_view_test.exs
@@ -23,4 +23,26 @@ defmodule Ex338.FantasyLeagueViewTest do
       assert Enum.map(sorted_teams, &(&1.name)) == ~w(A B)
     end
   end
+
+  describe "sort_and_rank/1" do
+    test "sorts teams by points and adds the rank to a team" do
+      team_a =
+        %{roster_positions: [
+          %{fantasy_player: %{championship_results: [%{rank: 1, points: 8}]}},
+          %{fantasy_player: %{championship_results: [%{rank: 2, points: 5}]}}
+        ], name: "A"}
+
+      team_b =
+        %{roster_positions: [
+          %{fantasy_player: %{championship_results: [%{rank: 1, points: 0}]}},
+          %{fantasy_player: %{championship_results: [%{rank: 2, points: 1}]}}
+        ], name: "B"}
+
+      teams = [team_b, team_a]
+
+      ranked_teams = FantasyLeagueView.sort_and_rank(teams)
+
+      assert Enum.map(ranked_teams, &({&1.name, &1.rank})) == [{"A", 1}, {"B", 2}]
+    end
+  end
 end

--- a/web/templates/fantasy_league/fantasy_teams_table.html.eex
+++ b/web/templates/fantasy_league/fantasy_teams_table.html.eex
@@ -11,9 +11,9 @@
       </tr>
     </thead>
     <tbody>
-      <%= for team <- sort_by_points(@fantasy_teams)  do %>
+      <%= for team <- sort_and_rank(@fantasy_teams)  do %>
         <tr>
-          <td>-</td>
+          <td><%= team.rank %></td>
           <td><%= link team.team_name, to: fantasy_team_path(@conn, :show, team.id) %></td>
           <td class="dues"><%= team.dues_paid %></td>
           <td><%= team.waiver_position %></td>

--- a/web/views/fantasy_league_view.ex
+++ b/web/views/fantasy_league_view.ex
@@ -3,7 +3,21 @@ defmodule Ex338.FantasyLeagueView do
 
   import Ex338.FantasyTeamView, only: [calculate_points: 1]
 
+  def sort_and_rank(fantasy_teams) do
+    fantasy_teams
+    |> sort_by_points
+    |> add_rank
+  end
+
   def sort_by_points(fantasy_teams) do
     Enum.sort(fantasy_teams, &(calculate_points(&1) >= calculate_points(&2)))
+  end
+
+  defp add_rank(fantasy_teams) do
+    {teams, _} = Enum.map_reduce fantasy_teams, 1, fn(team, acc) ->
+     {Map.put(team, :rank, acc), acc + 1}
+    end
+
+    teams
   end
 end


### PR DESCRIPTION
* The standings page displays the rank of the team instead of "-"
* Does not handle ties yet and second sort is by waiver position
* Closes #165