### PR TITLE
Add injured reserve status to roster positions

### DIFF
--- a/lib/ex338/roster_position/ir_position.ex
+++ b/lib/ex338/roster_position/ir_position.ex
@@ -1,0 +1,33 @@
+defmodule Ex338.RosterPosition.IRPosition do
+  @moduledoc false
+
+  def separate_from_active_for_teams(fantasy_teams) do
+    Enum.map(fantasy_teams, &(separate_from_active_for_team(&1)))
+  end
+
+  def separate_from_active_for_team(
+    %{roster_positions: roster_positions} = fantasy_team) do
+
+    {ir_positions, active_positions} =
+      split_ir_and_active_positions(roster_positions)
+
+    ir_positions = set_position_to_ir(ir_positions)
+
+    fantasy_team
+    |> Map.delete(:roster_positions)
+    |> Map.put(:ir_positions, ir_positions)
+    |> Map.put(:roster_positions, active_positions)
+  end
+
+  def separate_from_active_for_team(fantasy_team) do
+    fantasy_team
+  end
+
+  defp split_ir_and_active_positions(roster_positions) do
+    Enum.partition(roster_positions, &(&1.status == "injured_reserve"))
+  end
+
+  defp set_position_to_ir(ir_positions) do
+    Enum.map(ir_positions, &(Map.put(&1, :position, "Injured Reserve")))
+  end
+end

--- a/test/controllers/fantasy_player_controller_test.exs
+++ b/test/controllers/fantasy_player_controller_test.exs
@@ -10,20 +10,28 @@ defmodule Ex338.FantasyPlayerControllerTest do
     test "lists all owned/unowned fantasy players in a league", %{conn: conn} do
       league = insert(:fantasy_league)
       other_league = insert(:fantasy_league)
-      team = insert(:fantasy_team, team_name: "Brown", fantasy_league: league)
+      team_a = insert(:fantasy_team, team_name: "Brown", fantasy_league: league)
+      team_b = insert(:fantasy_team, team_name: "Axel", fantasy_league: league)
       other_team = insert(:fantasy_team, team_name: "Another Team",
                                          fantasy_league: other_league)
       player = insert(:fantasy_player)
+      ir_player = insert(:fantasy_player)
       unowned_player = insert(:fantasy_player)
-      insert(:roster_position, fantasy_team: team, fantasy_player: player)
-      insert(:roster_position, fantasy_team: other_team, fantasy_player: player)
+      insert(:roster_position, fantasy_team: team_a, fantasy_player: player,
+                               status: "active")
+      insert(:roster_position, fantasy_team: other_team, fantasy_player: player,
+                               status: "active")
+      insert(:roster_position, fantasy_team: team_b, fantasy_player: ir_player,
+                               status: "injured_reserve")
 
       conn = get conn, fantasy_league_fantasy_player_path(conn, :index, league.id)
 
       assert html_response(conn, 200) =~ ~r/Fantasy Players/
       assert String.contains?(conn.resp_body, player.player_name)
       assert String.contains?(conn.resp_body, unowned_player.player_name)
-      assert String.contains?(conn.resp_body, team.team_name)
+      assert String.contains?(conn.resp_body, ir_player.player_name)
+      assert String.contains?(conn.resp_body, team_a.team_name)
+      assert String.contains?(conn.resp_body, team_b.team_name)
       refute String.contains?(conn.resp_body, other_team.team_name)
     end
   end

--- a/test/controllers/fantasy_team_controller_test.exs
+++ b/test/controllers/fantasy_team_controller_test.exs
@@ -27,11 +27,16 @@ defmodule Ex338.FantasyTeamControllerTest do
       insert(:owner, user: conn.assigns.current_user, fantasy_team: team)
       player = insert(:fantasy_player)
       dropped_player = insert(:fantasy_player)
+      ir_player = insert(:fantasy_player)
       insert(:roster_position, position: "Unassigned", fantasy_team: team,
-                                          fantasy_player: player)
+                               fantasy_player: player)
       insert(:roster_position, fantasy_team: team,
                                fantasy_player: dropped_player,
                                status: "dropped")
+
+      insert(:roster_position, fantasy_team: team,
+                               fantasy_player: ir_player,
+                               status: "injured_reserve")
 
       conn = get conn, fantasy_team_path(conn, :show, team.id)
 
@@ -39,9 +44,10 @@ defmodule Ex338.FantasyTeamControllerTest do
       assert String.contains?(conn.resp_body, team.team_name)
       assert String.contains?(conn.resp_body, conn.assigns.current_user.name)
       assert String.contains?(conn.resp_body, player.player_name)
-      refute String.contains?(conn.resp_body, dropped_player.player_name)
+      assert String.contains?(conn.resp_body, ir_player.player_name)
       assert String.contains?(conn.resp_body, "75")
       assert String.contains?(conn.resp_body, "100")
+      refute String.contains?(conn.resp_body, dropped_player.player_name)
     end
   end
 

--- a/test/lib/ex338/roster_position/ir_position_test.exs
+++ b/test/lib/ex338/roster_position/ir_position_test.exs
@@ -1,0 +1,60 @@
+defmodule Ex338.RosterPosition.IRPositionTest do
+  use Ex338.ModelCase
+  alias Ex338.RosterPosition.IRPosition
+
+  describe "separate_from_active_for_teams/1" do
+    test "puts all ir position under ir_positions key and renames position" do
+      teams = [
+        %{roster_positions: [
+          %{status: "active"},
+          %{status: "active"},
+          %{status: "injured_reserve", position: "CFB"}
+        ]},
+        %{roster_positions: [
+          %{status: "active"},
+          %{status: "active"},
+          %{status: "active"},
+          %{status: "injured_reserve"}
+        ]}
+      ]
+
+
+      result = IRPosition.separate_from_active_for_teams(teams)
+      team_a = List.first(result)
+      team_b = List.last(result)
+      team_a_ir = List.first(team_a.ir_positions)
+
+      assert Enum.count(team_a.roster_positions) == 2
+      assert Enum.count(team_a.ir_positions) == 1
+      assert team_a_ir.position == "Injured Reserve"
+      assert Enum.count(team_b.roster_positions) == 3
+      assert Enum.count(team_b.ir_positions) == 1
+    end
+  end
+
+  describe "separate_from_active_for_team/1" do
+    test "puts all ir position under ir_positions key and renames position" do
+      team = %{roster_positions: [
+        %{status: "active"},
+        %{status: "active"},
+        %{status: "injured_reserve", position: "CFB"}
+      ]}
+
+
+      result = IRPosition.separate_from_active_for_team(team)
+      ir_position = List.first(result.ir_positions)
+
+      assert Enum.count(result.roster_positions) == 2
+      assert Enum.count(result.ir_positions) == 1
+      assert ir_position.position == "Injured Reserve"
+    end
+
+    test "returns fantasy team if no roster positions in map" do
+      team = %{name: "Brown"}
+
+      result = IRPosition.separate_from_active_for_team(team)
+
+      assert result.name == "Brown"
+    end
+  end
+end

--- a/test/models/roster_position_repo_test.exs
+++ b/test/models/roster_position_repo_test.exs
@@ -28,6 +28,32 @@ defmodule Ex338.RosterPositionRepoTest do
     end
   end
 
+  describe "current_positions/1" do
+    test "returns active & ir roster positions with championship results" do
+      player_a = insert(:fantasy_player)
+      player_b = insert(:fantasy_player)
+      player_c = insert(:fantasy_player)
+      team = insert(:fantasy_team)
+      insert(:roster_position, fantasy_team: team, fantasy_player: player_a,
+                               status: "injured_reserve")
+      insert(:roster_position, fantasy_team: team, fantasy_player: player_b,
+                               status: "active")
+      insert(:roster_position, fantasy_team: team, fantasy_player: player_c,
+                               status: "traded")
+      championship = insert(:championship, category: "overall")
+      insert(:championship_result, fantasy_player: player_a,
+                                   championship: championship)
+
+      results = RosterPosition
+                |> RosterPosition.current_positions
+                |> Repo.all
+      result  = List.first(results)
+
+      assert Enum.count(results) == 2
+      assert Enum.count(result.fantasy_player.championship_results) == 1
+    end
+  end
+
   describe "update_dropped_player/5" do
     test "updates roster position by team and player ids" do
       team   = insert(:fantasy_team)

--- a/web/models/roster_position.ex
+++ b/web/models/roster_position.ex
@@ -13,7 +13,7 @@ defmodule Ex338.RosterPosition do
   @positions ["CL", "CBB", "CFB", "CHK", "EPL", "KD", "LLWS", "MTn", "MLB",
               "NBA", "NFL", "NHL", "PGA", "WTn"] ++ @flex_positions
 
-  @status_options ["active", "dropped", "traded"]
+  @status_options ["active", "injured_reserve", "dropped", "traded"]
 
   schema "roster_positions" do
     belongs_to :fantasy_team, FantasyTeam
@@ -55,6 +55,15 @@ defmodule Ex338.RosterPosition do
 
     from r in query,
       where: r.status == "active",
+      preload: [fantasy_player: ^players_with_results]
+  end
+
+  def current_positions(query) do
+    players_with_results = FantasyPlayer
+                           |> FantasyPlayer.preload_overall_results
+
+    from r in query,
+      where: r.status == "injured_reserve" or r.status == "active",
       preload: [fantasy_player: ^players_with_results]
   end
 

--- a/web/templates/fantasy_team/show.html.eex
+++ b/web/templates/fantasy_team/show.html.eex
@@ -20,6 +20,6 @@
 
 <div class="fantasy-team-container">
   <div class="players-collection">
-<%= render "table.html", fantasy_team: @fantasy_team %>
+    <%= render "table.html", fantasy_team: @fantasy_team %>
   </div>
 </div>

--- a/web/templates/fantasy_team/table.html.eex
+++ b/web/templates/fantasy_team/table.html.eex
@@ -17,5 +17,8 @@
           flex_and_unassigned_positions(@fantasy_team.roster_positions)) do %>
       <%= render "table_row.html", roster_position: roster_position %>
     <% end %>
+    <%= for ir_position <- @fantasy_team.ir_positions do %>
+      <%= render "table_row.html", roster_position: ir_position %>
+    <% end %>
   </tbody>
 </table>


### PR DESCRIPTION
Add injured reserve status to roster positions to enable owners to add players to injured reserve, IAW league rules.