### PR TITLE
Fix typo in navigation header

### DIFF
--- a/web/templates/layout/header.html.eex
+++ b/web/templates/layout/header.html.eex
@@ -28,9 +28,9 @@
                 <li><%= link "Standings", to: fantasy_league_path(@conn, :show, 2) %></li>
                 <li><%= link "Teams", to: fantasy_league_fantasy_team_path(@conn, :index, 2) %></li>
                 <li><%= link "Players", to: fantasy_league_fantasy_player_path(@conn, :index, 2) %></li>
-                <li><%= link "Championships", to: fantasy_league_championship_path(@conn, :index, 1) %></li>
+                <li><%= link "Championships", to: fantasy_league_championship_path(@conn, :index, 2) %></li>
                 <li><%= link "Waivers", to: fantasy_league_waiver_path(@conn, :index, 2) %></li>
-                <li><%= link "Injured Reserves", to: fantasy_league_injured_reserve_path(@conn, :index, 1) %></li>
+                <li><%= link "Injured Reserves", to: fantasy_league_injured_reserve_path(@conn, :index, 2) %></li>
                 <li><%= link "Draft", to: fantasy_league_draft_pick_path(@conn, :index, 2) %></li>
                 <li><%= link "Trades", to: fantasy_league_trade_path(@conn, :index, 2) %></li>
                 <li><%= link "Owners", to: fantasy_league_owner_path(@conn, :index, 2) %></li>


### PR DESCRIPTION
* Injured reserve and championship links under Div B pointed to Div A