### PR TITLE
Remove admin & owner duplicate email addresses

### DIFF
--- a/lib/commish_email.ex
+++ b/lib/commish_email.ex
@@ -3,10 +3,14 @@ defmodule Ex338.CommishEmail do
   alias Ex338.{Owner, User, EmailTemplate, Mailer, Repo}
 
   def send_email_to_leagues(leagues, subject, message) do
+    owners = Owner.get_leagues_email_addresses(leagues)
+    admins = Repo.all(User.admin_emails)
+    recipients = unique_recipients(owners, admins)
+
     email_info =
       %{
-        to: Owner.get_leagues_email_addresses(leagues),
-        cc: Repo.all(User.admin_emails),
+        to: recipients,
+        cc: [],
         from: {"338 Commish", "no-reply@338admin.com"},
         subject: subject,
         message: message
@@ -15,5 +19,9 @@ defmodule Ex338.CommishEmail do
     email_info
     |> EmailTemplate.plain_text
     |> Mailer.deliver
+  end
+
+  def unique_recipients(owners, admins) do
+    Enum.uniq(owners ++ admins)
   end
 end

--- a/test/lib/commish_email_test.exs
+++ b/test/lib/commish_email_test.exs
@@ -14,8 +14,9 @@ defmodule Ex338.CommishEmailTest do
       message = "Here is the latest info!"
 
       email_info = %{
-        to: [{other_user.name, other_user.email}],
-        cc: [{admin_user.name, admin_user.email}],
+        to: [{other_user.name, other_user.email},
+             {admin_user.name, admin_user.email}],
+        cc: [],
         from: {"338 Commish", "no-reply@338admin.com"},
         subject: subject,
         message: message
@@ -28,6 +29,27 @@ defmodule Ex338.CommishEmailTest do
       )
 
       assert_email_sent EmailTemplate.plain_text(email_info)
+    end
+  end
+
+  describe "unique_recipients/2" do
+    test "combines admins and owners" do
+      admins = [{"Ryan", "ryan@example.com"}]
+      owners = [{"owner", "owner@example.com"}]
+
+      result = CommishEmail.unique_recipients(owners, admins)
+
+      assert result == (owners ++ admins)
+    end
+
+    test "combines admins and owners while removing duplicates" do
+      brown = {"Ryan", "ryan@example.com"}
+      owners = [brown, {"owner", "owner@example.com"}]
+      admins = [brown]
+
+      result = CommishEmail.unique_recipients(owners, admins)
+
+      assert result == owners
     end
   end
 end

--- a/web/controllers/commish_email_controller.ex
+++ b/web/controllers/commish_email_controller.ex
@@ -20,9 +20,9 @@ defmodule Ex338.CommishEmailController do
         conn
         |> put_flash(:info, "Email sent successfully")
         |> redirect(to: commish_email_path(conn, :new))
-      {:error, _reason} ->
+      {:error, {_code, reason}} ->
         conn
-        |> put_flash(:error, "There was an error while sending the email")
+        |> put_flash(:error, "Email failed to send: #{reason}")
         |> redirect(to: commish_email_path(conn, :new))
     end
   end


### PR DESCRIPTION
* SendGrid now errors if there are duplicate email addresses
* Update email to ensure all recipients are unique
* Improve error messages for emails
* Log the error reason when there is an erro in the notification email
* Closes #235