### PR TITLE
Allow admin to hide waivers

### DIFF
--- a/priv/repo/migrations/20170305200054_add_hide_waivers_to_sports_league.exs
+++ b/priv/repo/migrations/20170305200054_add_hide_waivers_to_sports_league.exs
@@ -1,0 +1,9 @@
+defmodule Ex338.Repo.Migrations.AddHideWaiversToSportsLeague do
+  use Ecto.Migration
+
+  def change do
+    alter table(:sports_leagues) do
+      add :hide_waivers, :boolean, default: false
+    end
+  end
+end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -144,6 +144,7 @@ defmodule Ex338.Factory do
       trade_deadline:    CalendarAssistant.days_from_now(3),
       waiver_deadline:   CalendarAssistant.days_from_now(3),
       championship_date: CalendarAssistant.days_from_now(3),
+      hide_waivers: false,
    }
   end
 

--- a/test/views/waiver_view_test.exs
+++ b/test/views/waiver_view_test.exs
@@ -43,4 +43,21 @@ defmodule Ex338.WaiverViewTest do
       assert result == false
     end
   end
+
+  describe "display_name/1" do
+    test "hides name if sport is hiding waiver claims" do
+      player = %{player_name: "Michigan", sports_league: %{hide_waivers: true}}
+
+      result = WaiverView.display_name(player)
+
+      assert result == "*****"
+    end
+    test "displays name if sport is not hiding waiver claims" do
+      player = %{player_name: "Michigan", sports_league: %{hide_waivers: false}}
+
+      result = WaiverView.display_name(player)
+
+      assert result == "Michigan"
+    end
+  end
 end

--- a/web/admin/waiver.ex
+++ b/web/admin/waiver.ex
@@ -13,6 +13,7 @@ defmodule Ex338.ExAdmin.Waiver do
           collection: Ex338.FantasyPlayer.get_all_players()
         input waiver, :drop_fantasy_player,
           collection: Ex338.FantasyPlayer.get_all_players()
+        input waiver, :hide_waivers
         input waiver, :process_at
         input waiver, :status, collection: Ex338.Waiver.status_options()
       end

--- a/web/emails/notification_email.ex
+++ b/web/emails/notification_email.ex
@@ -1,6 +1,7 @@
 defmodule Ex338.NotificationEmail do
   use Phoenix.Swoosh, view: Ex338.EmailView, layout: {Ex338.LayoutView, :email}
   import Ecto.Query, only: [preload: 2]
+  import Ex338.WaiverView, only: [display_name: 1]
   require Logger
   alias Ex338.{Waiver, Repo, Owner, User, Mailer}
 
@@ -43,7 +44,7 @@ defmodule Ex338.NotificationEmail do
   end
 
   defp waiver_headline(%Waiver{add_fantasy_player: player} = waiver) do
-    "338 Waiver: #{waiver.fantasy_team.team_name} claims #{player.player_name} (#{player.sports_league.abbrev})"
+    "338 Waiver: #{waiver.fantasy_team.team_name} claims #{display_name(player)} (#{player.sports_league.abbrev})"
   end
 
   defp get_recipients(league_id) do

--- a/web/models/sports_league.ex
+++ b/web/models/sports_league.ex
@@ -11,6 +11,7 @@ defmodule Ex338.SportsLeague do
     field :waiver_deadline, Ecto.DateTime
     field :trade_deadline, Ecto.DateTime
     field :championship_date, Ecto.DateTime
+    field :hide_waivers, :boolean
     has_many :fantasy_players, Ex338.FantasyPlayer
     has_many :championships, Ex338.Championship
 
@@ -23,7 +24,7 @@ defmodule Ex338.SportsLeague do
   def changeset(struct, params \\ %{}) do
     struct
     |> cast(params, [:league_name, :abbrev, :waiver_deadline, :trade_deadline,
-                     :championship_date])
+                     :championship_date, :hide_waivers])
     |> validate_required([:league_name, :abbrev, :waiver_deadline,
                           :trade_deadline, :championship_date])
   end

--- a/web/static/js/socket.js
+++ b/web/static/js/socket.js
@@ -3,9 +3,9 @@
 
 // To use Phoenix channels, the first step is to import Socket
 // and connect at the socket path in "lib/my_app/endpoint.ex":
-import {Socket} from "phoenix"
+// import {Socket} from "phoenix"
 
-let socket = new Socket("/socket", {params: {token: window.userToken}})
+// let socket = new Socket("/socket", {params: {token: window.userToken}})
 
 // When you connect, you'll often need to authenticate the client.
 // For example, imagine you have an authentication plug, `MyAuth`,
@@ -51,12 +51,12 @@ let socket = new Socket("/socket", {params: {token: window.userToken}})
 // Finally, pass the token on connect as below. Or remove it
 // from connect if you don't care about authentication.
 
-socket.connect()
+// socket.connect()
 
 // Now that you are connected, you can join channels with a topic:
-let channel = socket.channel("topic:subtopic", {})
-channel.join()
-  .receive("ok", resp => { console.log("Joined successfully", resp) })
-  .receive("error", resp => { console.log("Unable to join", resp) })
+// let channel = socket.channel("topic:subtopic", {})
+// channel.join()
+//   .receive("ok", resp => { console.log("Joined successfully", resp) })
+//   .receive("error", resp => { console.log("Unable to join", resp) })
 
-export default socket
+// export default socket

--- a/web/templates/email/waiver_submitted.html.eex
+++ b/web/templates/email/waiver_submitted.html.eex
@@ -1,7 +1,7 @@
 <h3><%= @waiver.fantasy_team.team_name %> submitted a new waiver</h3>
 <p><%= @waiver.fantasy_team.team_name %>'s current waiver position is #<%= @waiver.fantasy_team.waiver_position %>.</p>
 <%= if @waiver.add_fantasy_player do %>
-  <p><strong>Player to add: </strong><%= @waiver.add_fantasy_player.player_name %> (<%=@waiver.add_fantasy_player.sports_league.abbrev %>)</p>
+  <p><strong>Player to add: </strong><%= display_name(@waiver.add_fantasy_player) %> (<%=@waiver.add_fantasy_player.sports_league.abbrev %>)</p>
 <% end %>
 <%= if @waiver.drop_fantasy_player do %>
   <p><strong>Player to drop: </strong><%= @waiver.drop_fantasy_player.player_name %>(<%= @waiver.drop_fantasy_player.sports_league.abbrev %>)</p>

--- a/web/templates/waiver/pending_table.html.eex
+++ b/web/templates/waiver/pending_table.html.eex
@@ -16,7 +16,7 @@
         <td><%= waiver.fantasy_team.team_name %></td>
         <td><%= waiver.fantasy_team.waiver_position %></td>
         <%= if waiver.add_fantasy_player do %> 
-          <td><%= waiver.add_fantasy_player.player_name %> (<%= waiver.add_fantasy_player.sports_league.abbrev %>)</td>
+          <td><%= display_name(waiver.add_fantasy_player) %> (<%= waiver.add_fantasy_player.sports_league.abbrev %>)</td>
         <% else %>
           <td></td>
         <% end %>

--- a/web/views/email_view.ex
+++ b/web/views/email_view.ex
@@ -1,4 +1,5 @@
 defmodule Ex338.EmailView do
   use Ex338.Web, :view
 
+  import Ex338.WaiverView, only: [display_name: 1]
 end

--- a/web/views/waiver_view.ex
+++ b/web/views/waiver_view.ex
@@ -20,4 +20,8 @@ defmodule Ex338.WaiverView do
       :lt -> false
     end
   end
+
+  def display_name(%{sports_league: %{hide_waivers: true}}), do: "*****"
+
+  def display_name(%{player_name: name} = _player), do: name
 end


### PR DESCRIPTION
* Hide player name when Sports League hide_waivers attribute is true
* Need to hide during the blind waiver period by league rules during conference tournaments.
* Needed to mask the claimed player in the email and mask the claimed player for pending claims.
* Closes #247 