### PR TITLE
Update site to to use active_at and released_at dates instead of "active" status

### DIFF
--- a/test/models/championship_slot_repo_test.exs
+++ b/test/models/championship_slot_repo_test.exs
@@ -1,49 +1,115 @@
 defmodule Ex338.ChampionshipSlotRepoTest do
   use Ex338.ModelCase
 
-  alias Ex338.{ChampionshipSlot}
+  alias Ex338.{ChampionshipSlot, CalendarAssistant}
 
   describe "preload_assocs_by_league/2" do
-    test "preloads all assocs for a league" do
+    test "ordered, includes slots with & without results, only for championship" do
       player_a = insert(:fantasy_player)
       player_b = insert(:fantasy_player)
       f_league_a = insert(:fantasy_league)
-      f_league_b = insert(:fantasy_league)
       championship = insert(:championship)
       other_championship = insert(:championship)
       team_a = insert(:fantasy_team, fantasy_league: f_league_a)
-      team_b = insert(:fantasy_team, fantasy_league: f_league_b)
-      pos = insert(:roster_position, fantasy_team: team_a,
+      results_pos = insert(:roster_position, fantasy_team: team_a,
         fantasy_player: player_a)
-      other_pos = insert(:roster_position, fantasy_team: team_b,
-        fantasy_player: player_a)
-      slot_pos = insert(:roster_position, fantasy_team: team_a,
+      no_results_pos = insert(:roster_position, fantasy_team: team_a,
         fantasy_player: player_b)
       insert(:championship_slot, championship: championship,
-        roster_position: pos)
+        roster_position: results_pos, slot: 1)
       insert(:championship_slot, championship: championship,
-        roster_position: other_pos)
-      insert(:championship_slot, championship: championship,
-        roster_position: slot_pos)
-      insert(:championship_result, championship: championship, points: 8,
-        fantasy_player: player_a)
+        roster_position: no_results_pos, slot: 2)
+      expected_champ_result =
+        insert(:championship_result, championship: championship, points: 8,
+          fantasy_player: player_a)
       insert(:championship_result, championship: other_championship, points: 8,
         fantasy_player: player_a)
 
-      [slot_no_result, slot_result] =
+      [slot_result, slot_no_result] =
         ChampionshipSlot
         |> ChampionshipSlot.preload_assocs_by_league(f_league_a.id)
         |> Repo.all
 
-      %{championship_results: champ_results} =
+      %{championship_results: [champ_result]} =
         slot_result.roster_position.fantasy_player
 
-      assert slot_result.roster_position.id == pos.id
-      assert slot_result.roster_position.fantasy_team.id == team_a.id
+      assert slot_result.roster_position.id == results_pos.id
       assert slot_result.roster_position.fantasy_player.id == player_a.id
-      assert slot_result.roster_position.fantasy_player.id == player_a.id
-      assert Enum.count(champ_results) == 1
-      assert slot_no_result.roster_position.id == slot_pos.id
+      assert slot_no_result.roster_position.id == no_results_pos.id
+      assert champ_result.id == expected_champ_result.id
+    end
+
+    test "only includes assocs for a fantasy league" do
+      player_a = insert(:fantasy_player)
+      f_league_a = insert(:fantasy_league)
+      f_league_b = insert(:fantasy_league)
+      championship = insert(:championship)
+      team_a = insert(:fantasy_team, fantasy_league: f_league_a)
+      team_b = insert(:fantasy_team, fantasy_league: f_league_b)
+      pos_a = insert(:roster_position, fantasy_team: team_a,
+        fantasy_player: player_a)
+      pos_b = insert(:roster_position, fantasy_team: team_b,
+        fantasy_player: player_a)
+      insert(:championship_slot, championship: championship,
+        roster_position: pos_a)
+      insert(:championship_slot, championship: championship,
+        roster_position: pos_b)
+
+      result =
+        ChampionshipSlot
+        |> ChampionshipSlot.preload_assocs_by_league(f_league_a.id)
+        |> Repo.one
+
+      assert result.roster_position.id == pos_a.id
+    end
+
+    test "only slots with roster positions owned during championship" do
+      champ_date = CalendarAssistant.days_from_now(-10)
+      before_champ = CalendarAssistant.days_from_now(-15)
+      after_champ = CalendarAssistant.days_from_now(-1)
+
+      f_league_a = insert(:fantasy_league)
+      championship = insert(:championship, championship_at: champ_date)
+      player_a = insert(:fantasy_player)
+      player_b = insert(:fantasy_player)
+      player_c = insert(:fantasy_player)
+      player_d = insert(:fantasy_player)
+
+      team_a = insert(:fantasy_team, fantasy_league: f_league_a, team_name: "A")
+      pos_a = insert(:roster_position, fantasy_team: team_a,
+        fantasy_player: player_a, active_at: before_champ,
+        released_at: after_champ)
+      insert(:championship_slot, championship: championship,
+        roster_position: pos_a)
+
+      team_b = insert(:fantasy_team, fantasy_league: f_league_a, team_name: "B")
+      pos_b = insert(:roster_position, fantasy_team: team_a,
+        fantasy_player: player_b, active_at: before_champ,
+        released_at: nil)
+      insert(:championship_slot, championship: championship,
+        roster_position: pos_b)
+
+      team_c = insert(:fantasy_team, fantasy_league: f_league_a)
+      pos_c = insert(:roster_position, fantasy_team: team_a,
+        fantasy_player: player_c, active_at: after_champ,
+        released_at: nil)
+      insert(:championship_slot, championship: championship,
+        roster_position: pos_c)
+
+      team_d = insert(:fantasy_team, fantasy_league: f_league_a)
+      pos_d = insert(:roster_position, fantasy_team: team_a,
+        fantasy_player: player_d, active_at: before_champ,
+        released_at: before_champ)
+      insert(:championship_slot, championship: championship,
+        roster_position: pos_d)
+
+      [result_a, result_b] =
+        ChampionshipSlot
+        |> ChampionshipSlot.preload_assocs_by_league(f_league_a.id)
+        |> Repo.all
+
+      assert result_a.roster_position.id == pos_b.id
+      assert result_b.roster_position.id == pos_a.id
     end
   end
 end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -12,15 +12,9 @@ defmodule Ex338.Factory do
       title: sequence(:title, &"Championship ##{&1}"),
       sports_league: build(:sports_league),
       category: "overall",
-      trade_deadline_at: Ecto.DateTime.cast!(
-        %{day: 17, hour: 14, min: 0, month: 4, sec: 0, year: 2010}
-      ),
-      waiver_deadline_at: Ecto.DateTime.cast!(
-        %{day: 17, hour: 14, min: 0, month: 4, sec: 0, year: 2010}
-      ),
-      championship_at: Ecto.DateTime.cast!(
-        %{day: 17, hour: 14, min: 0, month: 4, sec: 0, year: 2010}
-      ),
+      trade_deadline_at: CalendarAssistant.days_from_now(30),
+      waiver_deadline_at: CalendarAssistant.days_from_now(30),
+      championship_at: CalendarAssistant.days_from_now(60),
     }
   end
 
@@ -118,7 +112,9 @@ defmodule Ex338.Factory do
     %Ex338.RosterPosition{
       position:       "Unassigned",
       fantasy_team:   build(:fantasy_team),
-      fantasy_player:   build(:fantasy_player)
+      fantasy_player:   build(:fantasy_player),
+      active_at: CalendarAssistant.days_from_now(-10),
+      released_at: nil
     }
   end
 

--- a/web/models/championship.ex
+++ b/web/models/championship.ex
@@ -98,7 +98,8 @@ defmodule Ex338.Championship do
         s.championship_id == cr.championship_id,
       where: c.overall_id == ^overall_id,
       where: f.fantasy_league_id == ^league_id,
-      where: r.status == "active",
+      where: r.active_at < c.championship_at,
+      where: (r.released_at > c.championship_at or is_nil(r.released_at)),
       order_by: [f.team_name, s.slot],
       group_by: [f.team_name, s.slot],
       select: %{slot: s.slot, team_name: f.team_name, points: sum(cr.points)}

--- a/web/models/championship_slot.ex
+++ b/web/models/championship_slot.ex
@@ -27,13 +27,15 @@ defmodule Ex338.ChampionshipSlot do
       join: r in assoc(s, :roster_position),
       join: f in assoc(r, :fantasy_team),
       join: p in assoc(r, :fantasy_player),
-      left_join: c in ChampionshipResult, on: c.fantasy_player_id == p.id and
-        s.championship_id == c.championship_id,
+      left_join: cr in ChampionshipResult, on: cr.fantasy_player_id == p.id and
+        s.championship_id == cr.championship_id,
+      join: c in assoc(s, :championship),
       where: f.fantasy_league_id == ^league_id,
-      where: r.status == "active",
+      where: r.active_at < c.championship_at,
+      where: (r.released_at > c.championship_at or is_nil(r.released_at)),
       order_by: [f.team_name, s.slot],
       preload: [roster_position: :fantasy_team],
-      preload: [roster_position: {r, fantasy_player: {p, championship_results: c}}],
+      preload: [roster_position: {r, fantasy_player: {p, championship_results: cr}}],
       preload: [:championship]
   end
 end


### PR DESCRIPTION
* Use active_at & released_at instead of "active"
* Closes issue #212 

Description of Bug:
Team A had Serena Williams during the Australian Open. She placed first scoring 8 points. Team A drops Serena Williams after the Australian Open is finished. Team B picked up Serena Williams after the Australian Open, but before the US Open. She placed first scoring 8 points.

Issues:

Serena Williams no longer shows up in Australian Open RosterSlots table or shows up under Team B.
-- Need update to ChampionshipSlot.preload_assocs_by_league/2

Team A no longer shows as an owner for Serena Williams in Australian Open results table. Team B shows in its place.
-- Need update to ChampionshipResults.preload_assocs_by_league/2

Team A no longer gets points in the Women's Tennis Overall standings. Team B has 16 points.
-- Championship.sum_slot_points/3