### PR TITLE
New RosterPosition created for InSeasonDraftPick by Owner

### DIFF
--- a/lib/ex338/in_season_draft_pick/admin.ex
+++ b/lib/ex338/in_season_draft_pick/admin.ex
@@ -1,15 +1,50 @@
 defmodule Ex338.InSeasonDraftPick.Admin do
   @moduledoc false
 
-  alias Ex338.{Commish, InSeasonDraftPick}
+  alias Ex338.{Commish, InSeasonDraftPick, RosterPosition}
   alias Ecto.Multi
 
   def update(draft_pick, params) do
-    league_id = draft_pick.draft_pick_asset.fantasy_team.fantasy_league_id
 
     Multi.new
-    |> Multi.update(:in_season_draft_pick,
-       InSeasonDraftPick.owner_changeset(draft_pick, params))
-    |> Multi.run(:email, &(Commish.InSeasonDraftEmail.send_update(&1, league_id)))
+    |> update_pick(draft_pick, params)
+    |> update_position(draft_pick)
+    |> new_position(draft_pick, params)
+    |> send_email(draft_pick)
+  end
+
+  defp update_pick(multi, draft_pick, params) do
+    Multi.update(multi, :update_pick,
+      InSeasonDraftPick.owner_changeset(draft_pick, params))
+  end
+
+  defp update_position(multi, draft_pick) do
+    params = %{
+      "released_at" => Ecto.DateTime.utc(),
+      "status" => "drafted_pick"
+    }
+
+    Multi.update(multi, :update_position,
+      RosterPosition.changeset(draft_pick.draft_pick_asset, params))
+  end
+
+  defp new_position(multi, draft_pick, %{"drafted_player_id" => player_id}) do
+    params = %{
+      "fantasy_team_id" => draft_pick.draft_pick_asset.fantasy_team_id,
+      "fantasy_player_id" => player_id,
+      "position" => draft_pick.draft_pick_asset.position,
+      "active_at" => Ecto.DateTime.utc(),
+      "status" => "active"
+    }
+
+    Multi.insert(multi, :new_position,
+      RosterPosition.changeset(%RosterPosition{}, params))
+  end
+
+  defp send_email(multi, draft_pick) do
+    league_id = draft_pick.draft_pick_asset.fantasy_team.fantasy_league_id
+
+    Multi.run(multi, :email,
+      &(Commish.InSeasonDraftEmail.send_update(&1, league_id)))
   end
 end

--- a/lib/ex338/in_season_draft_pick/store.ex
+++ b/lib/ex338/in_season_draft_pick/store.ex
@@ -3,7 +3,7 @@ defmodule Ex338.InSeasonDraftPick.Store do
 
   import Ecto.Query, only: [limit: 2]
 
-  alias Ex338.{InSeasonDraftPick, FantasyPlayer, Repo, Commish}
+  alias Ex338.{InSeasonDraftPick, FantasyPlayer, Repo}
 
   def pick_with_assocs(pick_id) do
     InSeasonDraftPick

--- a/test/lib/ex338/in_season_draft_pick/admin_test.exs
+++ b/test/lib/ex338/in_season_draft_pick/admin_test.exs
@@ -5,7 +5,7 @@ defmodule Ex338.InSeasonDraftPick.AdminTest do
   alias Ecto.Multi
 
   describe "update/2" do
-    test "with successful status, returns a multi with valid changeset" do
+    test "with valid player, returns a multi with valid changeset" do
       in_season_draft_pick = insert(:in_season_draft_pick)
       player = insert(:fantasy_player)
       params = %{"drafted_player_id" => player.id}
@@ -13,25 +13,32 @@ defmodule Ex338.InSeasonDraftPick.AdminTest do
       multi = Admin.update(in_season_draft_pick, params)
 
       assert [
-        {:in_season_draft_pick, {:update, changeset, []}},
+        {:update_pick, {:update, changeset, []}},
+        {:update_position, {:update, old_pos_changeset, []}},
+        {:new_position, {:insert, new_pos_changeset, []}},
         {:email, {:run, _function}}
       ] = Multi.to_list(multi)
 
       assert changeset.valid?
+      assert old_pos_changeset.valid?
+      assert new_pos_changeset.valid?
     end
 
-    test "with unsuccessful status, returns a multi with valid changeset" do
+    test "with blank player, returns a multi with an invalid changeset" do
       in_season_draft_pick = insert(:in_season_draft_pick)
-      params = %{"drafted_player_id" => nil}
+      params = %{"drafted_player_id" => ""}
 
       multi = Admin.update(in_season_draft_pick, params)
 
       assert [
-        {:in_season_draft_pick, {:update, changeset, []}},
+        {:update_pick, {:update, changeset, []}},
+        {:update_position, {:update, old_pos_changeset, []}},
+        {:new_position, {:insert, _new_pos_changeset, []}},
         {:email, {:run, _function}}
       ] = Multi.to_list(multi)
 
       refute changeset.valid?
+      assert old_pos_changeset.valid?
     end
   end
 end

--- a/test/models/in_season_draft_pick_test.exs
+++ b/test/models/in_season_draft_pick_test.exs
@@ -92,6 +92,8 @@ defmodule Ex338.InSeasonDraftPickTest do
       [owner] = result.draft_pick_asset.fantasy_team.owners
 
       assert result.draft_pick_asset.fantasy_team.id == team.id
+      assert result.draft_pick_asset.championship_slots == []
+      assert Enum.count(result.draft_pick_asset.in_season_draft_picks) == 1
       assert result.drafted_player.id == player.id
       assert result.championship.id == championship.id
       assert owner.id == pick_owner.id

--- a/web/controllers/in_season_draft_pick_controller.ex
+++ b/web/controllers/in_season_draft_pick_controller.ex
@@ -8,7 +8,8 @@ defmodule Ex338.InSeasonDraftPickController do
   plug :load_and_authorize_resource, model: InSeasonDraftPick,
     only: [:edit, :update],
     preload: [:championship, :drafted_player,
-             [draft_pick_asset: [fantasy_team: :owners]]],
+             [draft_pick_asset: [:championship_slots, :in_season_draft_picks,
+               :fantasy_player, fantasy_team: :owners]]],
     unauthorized_handler: {Authorization, :handle_unauthorized}
 
   def edit(conn, %{"id" => _id}) do
@@ -28,7 +29,7 @@ defmodule Ex338.InSeasonDraftPickController do
     pick = conn.assigns.in_season_draft_pick
 
     case InSeasonDraftPick.Store.draft_player(pick, params) do
-      {:ok,  %{in_season_draft_pick: pick}} ->
+      {:ok,  %{update_pick: pick}} ->
         league_id = pick.draft_pick_asset.fantasy_team.fantasy_league_id
 
         conn

--- a/web/models/in_season_draft_pick.ex
+++ b/web/models/in_season_draft_pick.ex
@@ -39,7 +39,8 @@ defmodule Ex338.InSeasonDraftPick do
   def preload_assocs(query) do
     from d in query,
       order_by: [d.position],
-      preload: [draft_pick_asset: [:fantasy_player, [fantasy_team: :owners]]],
+      preload: [draft_pick_asset: [:fantasy_player, :in_season_draft_picks,
+                :championship_slots, [fantasy_team: :owners]]],
       preload: [:championship, drafted_player: :sports_league]
   end
 


### PR DESCRIPTION
New RosterPosition created for InSeasonDraftPick
    
* A new RosterPosition is created when an owner drafts an InSeasonDraftPick
* Uses information from the draft_pick_asset to build the changeset
* Closes #267