### PR TITLE
Update generator for roster slots and create one for in season draft picks

### DIFF
--- a/lib/ex338/roster_position/store.ex
+++ b/lib/ex338/roster_position/store.ex
@@ -1,0 +1,15 @@
+defmodule Ex338.RosterPosition.Store do
+  @moduledoc false
+
+  alias Ex338.{RosterPosition, Repo}
+
+  def positions_for_draft(fantasy_league_id, championship_id) do
+    RosterPosition
+    |> RosterPosition.all_active
+    |> RosterPosition.all_draft_picks
+    |> RosterPosition.from_league(fantasy_league_id)
+    |> RosterPosition.sport_from_champ(championship_id)
+    |> RosterPosition.preload_assocs
+    |> Repo.all
+  end
+end

--- a/test/controllers/in_season_draft_order_controller_test.exs
+++ b/test/controllers/in_season_draft_order_controller_test.exs
@@ -1,0 +1,86 @@
+defmodule Ex338.InSeasonDraftOrderControllerTest do
+  use Ex338.ConnCase
+  alias Ex338.{InSeasonDraftPick, User}
+
+  setup %{conn: conn} do
+    user = %User{name: "test", email: "test@example.com", id: 1}
+    {:ok, conn: assign(conn, :current_user, user), user: user}
+  end
+
+  describe "create/2" do
+    test "admin creates draft picks for a championship", %{conn: conn} do
+      conn = put_in(conn.assigns.current_user.admin, true)
+      league = insert(:fantasy_league)
+      team_a = insert(:fantasy_team, fantasy_league: league)
+      team_b = insert(:fantasy_team, fantasy_league: league)
+
+      sport = insert(:sports_league)
+      championship =
+        insert(:championship, category: "overall", sports_league: sport)
+      player_1 = insert(:fantasy_player, player_name: "KD Pick #1",
+       sports_league: sport, draft_pick: true)
+      player_2 = insert(:fantasy_player, player_name: "KD Pick #2",
+       sports_league: sport, draft_pick: true)
+      player_3 = insert(:fantasy_player, player_name: "KD Pick #3",
+       sports_league: sport, draft_pick: true)
+
+      insert(:roster_position, fantasy_player: player_1, fantasy_team: team_a)
+      insert(:roster_position, fantasy_player: player_2, fantasy_team: team_b)
+      insert(:roster_position, fantasy_player: player_3, fantasy_team: team_a)
+
+      attrs = %{championship_id: championship.id}
+
+      conn = post conn, fantasy_league_in_season_draft_order_path(
+        conn, :create, league.id, attrs)
+
+      results = Repo.all(InSeasonDraftPick)
+
+      assert Enum.count(results) == 3
+      assert redirected_to(conn) ==
+        fantasy_league_championship_path(conn, :show, league.id, championship.id)
+    end
+
+    test "handles error", %{conn: conn} do
+      conn = put_in(conn.assigns.current_user.admin, true)
+      league = insert(:fantasy_league)
+      team_a = insert(:fantasy_team, fantasy_league: league)
+      team_b = insert(:fantasy_team, fantasy_league: league)
+
+      sport = insert(:sports_league)
+      championship =
+        insert(:championship, category: "overall", sports_league: sport)
+      player_1 = insert(:fantasy_player, player_name: "Wrong Name",
+       sports_league: sport, draft_pick: true)
+      player_2 = insert(:fantasy_player, player_name: "KD Pick #2",
+       sports_league: sport, draft_pick: true)
+      player_3 = insert(:fantasy_player, player_name: "KD Pick #3",
+       sports_league: sport, draft_pick: true)
+
+      insert(:roster_position, fantasy_player: player_1, fantasy_team: team_a)
+      insert(:roster_position, fantasy_player: player_2, fantasy_team: team_b)
+      insert(:roster_position, fantasy_player: player_3, fantasy_team: team_a)
+
+      attrs = %{championship_id: championship.id}
+
+      conn = post conn, fantasy_league_in_season_draft_order_path(
+        conn, :create, league.id, attrs)
+
+      results = Repo.all(InSeasonDraftPick)
+
+      assert Enum.count(results) == 0
+      assert redirected_to(conn) ==
+        fantasy_league_championship_path(conn, :show, league.id, championship.id)
+    end
+
+    test "redirects to root if user is not admin", %{conn: conn} do
+      league = insert(:fantasy_league)
+      championship = insert(:championship, category: "overall")
+      attrs = %{championship_id: championship.id}
+
+      conn = post conn, fantasy_league_in_season_draft_order_path(
+        conn, :create, league.id, attrs)
+
+      assert html_response(conn, 302) =~ ~r/redirected/
+    end
+  end
+end

--- a/test/lib/ex338/in_season_draft_pick/admin_test.exs
+++ b/test/lib/ex338/in_season_draft_pick/admin_test.exs
@@ -1,7 +1,7 @@
 defmodule Ex338.InSeasonDraftPick.AdminTest do
   use Ex338.ModelCase
 
-  alias Ex338.{InSeasonDraftPick.Admin}
+  alias Ex338.{InSeasonDraftPick.Admin, RosterPosition, FantasyPlayer}
   alias Ecto.Multi
 
   describe "update/2" do
@@ -39,6 +39,52 @@ defmodule Ex338.InSeasonDraftPick.AdminTest do
 
       refute changeset.valid?
       assert old_pos_changeset.valid?
+    end
+  end
+
+  describe "generate_picks/3" do
+    test "generates draft picks from roster positions" do
+      champ_id = 1
+      positions = [
+        %RosterPosition{id: 1, fantasy_player_id: 2, fantasy_player:
+            %FantasyPlayer{player_name: "KD Pick #1"}},
+        %RosterPosition{id: 2, fantasy_player_id: 3, fantasy_player:
+            %FantasyPlayer{player_name: "KD Pick #2"}},
+      ]
+
+      multi = Admin.generate_picks(positions, champ_id)
+
+      assert [
+        {:new_pick_1, {:insert, new_pos1_changeset, []}},
+        {:new_pick_2, {:insert, new_pos2_changeset, []}}
+      ] = Multi.to_list(multi)
+
+      assert new_pos1_changeset.valid?
+      assert new_pos2_changeset.valid?
+    end
+
+    test "handles incorrect name" do
+      champ_id = 1
+      positions = [
+        %RosterPosition{id: 1, fantasy_player_id: 2, fantasy_player:
+            %FantasyPlayer{player_name: "Wrong Name"}},
+        %RosterPosition{id: 2, fantasy_player_id: 3, fantasy_player:
+            %FantasyPlayer{player_name: "Also Wrong"}},
+        %RosterPosition{id: 3, fantasy_player_id: 5, fantasy_player:
+            %FantasyPlayer{player_name: "KD Pick #3"}},
+      ]
+
+      multi = Admin.generate_picks(positions, champ_id)
+
+      assert [
+        {_, {:insert, new_pos1_changeset, []}},
+        {_, {:insert, new_pos2_changeset, []}},
+        {:new_pick_3, {:insert, new_pos3_changeset, []}}
+      ] = Multi.to_list(multi)
+
+      refute new_pos1_changeset.valid?
+      refute new_pos2_changeset.valid?
+      assert new_pos3_changeset.valid?
     end
   end
 end

--- a/test/lib/ex338/roster_position/store_test.exs
+++ b/test/lib/ex338/roster_position/store_test.exs
@@ -1,0 +1,41 @@
+defmodule Ex338.RosterPosition.StoreTest do
+  use Ex338.ModelCase
+  alias Ex338.{RosterPosition.Store}
+
+  describe "positions_for_draft/2" do
+    test "returns all positions for a championship in a league" do
+      league = insert(:fantasy_league)
+      other_league = insert(:fantasy_league)
+      team_a = insert(:fantasy_team, fantasy_league: league)
+      team_b = insert(:fantasy_team, fantasy_league: other_league)
+
+      sport = insert(:sports_league)
+      other_sport = insert(:sports_league)
+      championship =
+        insert(:championship, category: "overall", sports_league: sport)
+
+      player_1 =
+        insert(:fantasy_player, sports_league: sport, draft_pick: true)
+      player_2 =
+        insert(:fantasy_player, sports_league: other_sport, draft_pick: true)
+      player_3 =
+        insert(:fantasy_player, sports_league: sport, draft_pick: false)
+      player_4 =
+        insert(:fantasy_player, sports_league: sport, draft_pick: true)
+
+      pos =
+        insert(:roster_position, fantasy_player: player_1, fantasy_team: team_a,
+          status: "active")
+      insert(:roster_position, fantasy_player: player_1, fantasy_team: team_b)
+      insert(:roster_position, fantasy_player: player_2, fantasy_team: team_a)
+      insert(:roster_position, fantasy_player: player_3, fantasy_team: team_a)
+      insert(:roster_position, fantasy_player: player_4, fantasy_team: team_a,
+        status: "traded")
+
+      [result] = Store.positions_for_draft(league.id, championship.id)
+
+      assert result.id == pos.id
+      assert result.fantasy_player.player_name == player_1.player_name
+    end
+  end
+end

--- a/test/models/in_season_draft_pick_test.exs
+++ b/test/models/in_season_draft_pick_test.exs
@@ -35,6 +35,56 @@ defmodule Ex338.InSeasonDraftPickTest do
         InSeasonDraftPick.owner_changeset(%InSeasonDraftPick{}, @invalid_attrs)
       refute changeset.valid?
     end
+
+    test "valid if next pick" do
+      league = insert(:fantasy_league)
+
+      team = insert(:fantasy_team, fantasy_league: league)
+      pick = insert(:fantasy_player, draft_pick: true)
+      pick_asset =
+        insert(:roster_position, fantasy_team: team, fantasy_player: pick)
+      drafted_player = insert(:fantasy_player, draft_pick: false)
+      insert(:in_season_draft_pick, draft_pick_asset: pick_asset, position: 1,
+        drafted_player: drafted_player)
+
+      team_b   = insert(:fantasy_team, fantasy_league: league)
+      pick_b   = insert(:fantasy_player, draft_pick: true)
+      pick_asset_b =
+        insert(:roster_position, fantasy_team: team_b, fantasy_player: pick_b)
+      next_pick =
+        insert(:in_season_draft_pick, draft_pick_asset: pick_asset_b, position: 2)
+
+      player = insert(:fantasy_player, draft_pick: false)
+      attrs = %{drafted_player_id: player.id}
+
+      changeset = InSeasonDraftPick.owner_changeset(next_pick, attrs)
+
+      assert changeset.valid?
+    end
+
+    test "invalid if not next pick" do
+      league = insert(:fantasy_league)
+
+      team = insert(:fantasy_team, fantasy_league: league)
+      pick = insert(:fantasy_player, draft_pick: true)
+      pick_asset =
+        insert(:roster_position, fantasy_team: team, fantasy_player: pick)
+      insert(:in_season_draft_pick, draft_pick_asset: pick_asset, position: 1)
+
+      team_b   = insert(:fantasy_team, fantasy_league: league)
+      pick_b   = insert(:fantasy_player, draft_pick: true)
+      pick_asset_b =
+        insert(:roster_position, fantasy_team: team_b, fantasy_player: pick_b)
+      future_pick =
+        insert(:in_season_draft_pick, draft_pick_asset: pick_asset_b, position: 2)
+
+      player = insert(:fantasy_player, draft_pick: false)
+      attrs = %{drafted_player_id: player.id}
+
+      changeset = InSeasonDraftPick.owner_changeset(future_pick, attrs)
+
+      refute changeset.valid?
+    end
   end
 
   describe "preload assocs by league" do

--- a/test/models/roster_position_repo_test.exs
+++ b/test/models/roster_position_repo_test.exs
@@ -29,7 +29,7 @@ defmodule Ex338.RosterPositionRepoTest do
   end
 
   describe "active_by_sports_league/2" do
-    test "only returns active roster positions with championship results" do
+    test "only returns active roster positions from a sport" do
       league = insert(:sports_league)
       other_league = insert(:sports_league)
       player_a = insert(:fantasy_player, sports_league: league)
@@ -122,6 +122,90 @@ defmodule Ex338.RosterPositionRepoTest do
         |> Repo.all
 
       assert result.fantasy_team.id == team.id
+    end
+  end
+
+  describe "from_league/2" do
+    test "returns roster positions for a given league with teams preloaded" do
+      league = insert(:fantasy_league)
+      other_league = insert(:fantasy_league)
+      team = insert(:fantasy_team, fantasy_league: league)
+      other_team = insert(:fantasy_team, fantasy_league: other_league)
+      pos = insert(:roster_position, fantasy_team: team)
+      insert(:roster_position, fantasy_team: other_team)
+
+      [result] =
+        RosterPosition
+        |> RosterPosition.from_league(league.id)
+        |> Repo.all
+
+      assert result.id == pos.id
+    end
+  end
+
+  describe "sport_from_champ/2" do
+    test "returns positions for a sport from a championship" do
+      sport = insert(:sports_league)
+      championship = insert(:championship, sports_league: sport)
+      other_sport = insert(:sports_league)
+      player_a = insert(:fantasy_player, sports_league: sport)
+      player_b = insert(:fantasy_player, sports_league: other_sport)
+      pos = insert(:roster_position, fantasy_player: player_a)
+      insert(:roster_position, fantasy_player: player_b)
+
+      result = RosterPosition
+               |> RosterPosition.sport_from_champ(championship.id)
+               |> Repo.one
+
+      assert result.id == pos.id
+    end
+  end
+
+  describe "all_active/1" do
+    test "only returns active roster positions" do
+      league = insert(:sports_league)
+      player_a = insert(:fantasy_player, sports_league: league)
+      player_b = insert(:fantasy_player, sports_league: league)
+      pos = insert(:roster_position, fantasy_player: player_a, status: "active")
+      insert(:roster_position, fantasy_player: player_b, status: "traded")
+
+      result = RosterPosition
+               |> RosterPosition.all_active
+               |> Repo.one
+
+      assert result.id == pos.id
+    end
+  end
+
+  describe "all_draft_picks/1" do
+    test "returns all positions where draft pick is true" do
+      pick = insert(:fantasy_player, draft_pick: true)
+      player = insert(:fantasy_player, draft_pick: false)
+      pos = insert(:roster_position, fantasy_player: pick)
+      insert(:roster_position, fantasy_player: player)
+
+      result = RosterPosition
+               |> RosterPosition.all_draft_picks
+               |> Repo.one
+
+      assert result.id == pos.id
+    end
+  end
+
+  describe "preload_assocs/1" do
+    test "preloads assocs for RosterPosition struct" do
+      player = insert(:fantasy_player)
+      team = insert(:fantasy_team)
+      insert(:roster_position, fantasy_team: team, fantasy_player: player)
+
+      result = RosterPosition
+               |> RosterPosition.preload_assocs
+               |> Repo.one
+
+      assert result.fantasy_team.id == team.id
+      assert result.fantasy_player.id == player.id
+      assert result.championship_slots == []
+      assert result.in_season_draft_picks == []
     end
   end
 end

--- a/test/views/championship_view_test.exs
+++ b/test/views/championship_view_test.exs
@@ -1,6 +1,6 @@
 defmodule Ex338.ChampionshipViewTest do
   use Ex338.ConnCase, async: true
-  alias Ex338.{ChampionshipView}
+  alias Ex338.{ChampionshipView, User, Championship, ChampionshipSlot}
 
   describe "get_team_name/1" do
     test "returns name from a fantasy team struct" do
@@ -48,6 +48,46 @@ defmodule Ex338.ChampionshipViewTest do
       results = ChampionshipView.filter_category(championships, "event")
 
       assert Enum.map(results, &(&1.name)) == ~w(C D)
+    end
+  end
+
+  describe "show_create_slots/2" do
+    test "return true if admin, event, and no slots" do
+      user = %User{admin: true}
+      championship = %Championship{category: "event", championship_slots: []}
+
+      result = ChampionshipView.show_create_slots(user, championship)
+
+      assert result == true
+    end
+
+    test "return false if admin, event, and slots" do
+      user = %User{admin: true}
+      championship =
+        %Championship{category: "event", championship_slots: [
+          %ChampionshipSlot{}]}
+
+      result = ChampionshipView.show_create_slots(user, championship)
+
+      assert result == false
+    end
+
+    test "return false if not admin" do
+      user = %User{admin: false}
+      championship = %Championship{category: "event", championship_slots: []}
+
+      result = ChampionshipView.show_create_slots(user, championship)
+
+      assert result == false
+    end
+
+    test "return false if overall" do
+      user = %User{admin: true}
+      championship = %Championship{category: "overall", championship_slots: []}
+
+      result = ChampionshipView.show_create_slots(user, championship)
+
+      assert result == false
     end
   end
 end

--- a/test/views/championship_view_test.exs
+++ b/test/views/championship_view_test.exs
@@ -1,6 +1,7 @@
 defmodule Ex338.ChampionshipViewTest do
   use Ex338.ConnCase, async: true
-  alias Ex338.{ChampionshipView, User, Championship, ChampionshipSlot}
+  alias Ex338.{ChampionshipView, User, Championship, ChampionshipSlot,
+               InSeasonDraftPick}
 
   describe "get_team_name/1" do
     test "returns name from a fantasy team struct" do
@@ -86,6 +87,49 @@ defmodule Ex338.ChampionshipViewTest do
       championship = %Championship{category: "overall", championship_slots: []}
 
       result = ChampionshipView.show_create_slots(user, championship)
+
+      assert result == false
+    end
+  end
+
+  describe "show_create_picks/2" do
+    test "return true if admin, in_season_draft, and no picks" do
+      user = %User{admin: true}
+      championship =
+        %Championship{in_season_draft: true, in_season_draft_picks: []}
+
+      result = ChampionshipView.show_create_picks(user, championship)
+
+      assert result == true
+    end
+
+    test "return false if picks already created" do
+      user = %User{admin: true}
+      championship =
+        %Championship{in_season_draft: true, in_season_draft_picks: [
+          %InSeasonDraftPick{}]}
+
+      result = ChampionshipView.show_create_picks(user, championship)
+
+      assert result == false
+    end
+
+    test "return false if not admin" do
+      user = %User{admin: false}
+      championship =
+        %Championship{in_season_draft: true, in_season_draft_picks: []}
+
+      result = ChampionshipView.show_create_picks(user, championship)
+
+      assert result == false
+    end
+
+    test "return false if in season draft is false" do
+      user = %User{admin: true}
+      championship =
+        %Championship{in_season_draft: false, in_season_draft_picks: []}
+
+      result = ChampionshipView.show_create_picks(user, championship)
 
       assert result == false
     end

--- a/web/controllers/in_season_draft_order_controller.ex
+++ b/web/controllers/in_season_draft_order_controller.ex
@@ -1,0 +1,30 @@
+defmodule Ex338.InSeasonDraftOrderController do
+  use Ex338.Web, :controller
+
+  alias Ex338.{InSeasonDraftPick}
+
+  def create(conn,
+    %{"fantasy_league_id" => league_id, "championship_id" => champ_id}) do
+
+    case InSeasonDraftPick.Store.create_picks_for_league(league_id, champ_id) do
+      {:ok, new_picks} ->
+        conn
+        |> put_flash(:info, "#{num_picks(new_picks)} picks successfully created.")
+        |> redirect(to:
+           fantasy_league_championship_path(conn, :show, league_id, champ_id))
+
+      {:error, _, changeset, _} ->
+        conn
+        |> put_flash(:info,
+           "Error when creating draft picks: #{inspect(changeset.errors)}")
+        |> redirect(to:
+           fantasy_league_championship_path(conn, :show, league_id, champ_id))
+    end
+  end
+
+  defp num_picks(picks) do
+    picks
+    |> Enum.count
+    |> Integer.to_string
+  end
+end

--- a/web/models/in_season_draft_pick.ex
+++ b/web/models/in_season_draft_pick.ex
@@ -2,6 +2,8 @@ defmodule Ex338.InSeasonDraftPick do
   @moduledoc false
   use Ex338.Web, :model
 
+  alias Ex338.InSeasonDraftPick
+
   schema "in_season_draft_picks" do
     field :position, :integer
     field :next_pick, :boolean, virtual: true, default: false
@@ -26,6 +28,27 @@ defmodule Ex338.InSeasonDraftPick do
     pick
     |> cast(params, [:drafted_player_id])
     |> validate_required([:drafted_player_id])
+    |> validate_is_next_pick
+  end
+
+  defp validate_is_next_pick(%{
+    data: %{draft_pick_asset: %{fantasy_team: %{fantasy_league_id: league_id}}}}
+    = pick_changeset) do
+
+    num_picks = 1
+    [next_pick] = InSeasonDraftPick.Store.next_picks(league_id, num_picks)
+
+    compare_to_next_pick(pick_changeset.data.id, next_pick.id, pick_changeset)
+  end
+
+  defp validate_is_next_pick(pick_changeset), do: pick_changeset
+
+  defp compare_to_next_pick(next_pick, next_pick, pick_changeset) do
+    pick_changeset
+  end
+
+  defp compare_to_next_pick(_pick, _next_pick, pick_changeset) do
+    add_error(pick_changeset, :drafted_player_id, "You don't have the next pick")
   end
 
   def draft_order(query) do

--- a/web/router.ex
+++ b/web/router.ex
@@ -74,6 +74,7 @@ defmodule Ex338.Router do
 
     resources "/fantasy_leagues", FantasyLeagueController, only: [] do
       resources "/championship_slot_admin", ChampionshipSlotAdminController, only: [:create]
+      resources "/in_season_draft_order", InSeasonDraftOrderController, only: [:create]
     end
   end
 

--- a/web/templates/championship/show.html.eex
+++ b/web/templates/championship/show.html.eex
@@ -4,7 +4,7 @@
 <p><strong>Trade Deadline: </strong><%= short_datetime_pst(@championship.trade_deadline_at) %></p>
 <p><strong>Championship Date: </strong><%= short_date(@championship.championship_at) %></p>
 <p>* All dates and times are in Pacific Standard Time (PST)/Pacific Daylight Time (PDT).</p>
-<%= if @current_user.admin == true do %>
+<%= if show_create_slots(@current_user, @championship) do %>
   <p>
   <%= 
     link "Create Roster Slots", 

--- a/web/templates/championship/show.html.eex
+++ b/web/templates/championship/show.html.eex
@@ -15,6 +15,17 @@
   </p>
 <% end %>
 
+<%= if show_create_picks(@current_user, @championship) do %>
+  <p>
+  <%= 
+    link "Create Draft Picks", 
+      to: fantasy_league_in_season_draft_order_path(
+      @conn, :create, @fantasy_league.id, %{championship_id: @championship.id}),
+      class: "btn", method: :post 
+  %>
+  </p>
+<% end %>
+
 <%= if @championship.events == [] do %>
 
   <div class="flex-container">

--- a/web/views/championship_view.ex
+++ b/web/views/championship_view.ex
@@ -12,4 +12,13 @@ defmodule Ex338.ChampionshipView do
   def filter_category(championships, category) do
     Enum.filter(championships, &(&1.category) == category)
   end
+
+  def show_create_slots(
+    %{admin: true}, %{category: "event", championship_slots: []}) do
+     true
+  end
+
+  def show_create_slots(_user, _championship) do
+    false
+  end
 end

--- a/web/views/championship_view.ex
+++ b/web/views/championship_view.ex
@@ -21,4 +21,13 @@ defmodule Ex338.ChampionshipView do
   def show_create_slots(_user, _championship) do
     false
   end
+
+  def show_create_picks(
+    %{admin: true}, %{in_season_draft: true, in_season_draft_picks: []}) do
+     true
+  end
+
+  def show_create_picks(_user, _championship) do
+    false
+  end
 end

--- a/web/views/view_helpers.ex
+++ b/web/views/view_helpers.ex
@@ -1,5 +1,5 @@
 defmodule Ex338.ViewHelpers do
-  alias Ex338.{FantasyTeam, User, DraftPick, InSeasonDraftPick}
+  alias Ex338.{FantasyTeam, User, InSeasonDraftPick}
   import Calendar.Strftime
 
   def format_players_for_select(players) do


### PR DESCRIPTION
Limit when create roster slot button is shown
* Only shown to admin, category: event, and when none are present
* Reduces risk of admin accidently creating unnecessary slots
* Closes #275