### PR TITLE
Move in season draft email out of Ecto multi transaction

### DIFF
--- a/lib/ex338/commish/in_season_draft_email.ex
+++ b/lib/ex338/commish/in_season_draft_email.ex
@@ -6,7 +6,7 @@ defmodule Ex338.Commish.InSeasonDraftEmail do
   alias Ex338.{FantasyLeague, InSeasonDraftPick, Owner, User, Mailer,
                NotificationEmail}
 
-  def send_update(_in_season_draft_pick, league_id) do
+  def send_update(league_id) do
     num_picks = 5
     email_data = in_season_draft_email_data(league_id, num_picks)
     email = NotificationEmail.in_season_draft_update(email_data)

--- a/lib/ex338/in_season_draft_pick/admin.ex
+++ b/lib/ex338/in_season_draft_pick/admin.ex
@@ -1,7 +1,7 @@
 defmodule Ex338.InSeasonDraftPick.Admin do
   @moduledoc false
 
-  alias Ex338.{Commish, InSeasonDraftPick, RosterPosition}
+  alias Ex338.{InSeasonDraftPick, RosterPosition}
   alias Ecto.Multi
 
   def generate_picks(roster_positions, championship_id) do
@@ -39,7 +39,6 @@ defmodule Ex338.InSeasonDraftPick.Admin do
     |> update_pick(draft_pick, params)
     |> update_position(draft_pick)
     |> new_position(draft_pick, params)
-    |> send_email(draft_pick)
   end
 
   defp update_pick(multi, draft_pick, params) do
@@ -68,12 +67,5 @@ defmodule Ex338.InSeasonDraftPick.Admin do
 
     Multi.insert(multi, :new_position,
       RosterPosition.changeset(%RosterPosition{}, params))
-  end
-
-  defp send_email(multi, draft_pick) do
-    league_id = draft_pick.draft_pick_asset.fantasy_team.fantasy_league_id
-
-    Multi.run(multi, :email,
-      &(Commish.InSeasonDraftEmail.send_update(&1, league_id)))
   end
 end

--- a/test/lib/ex338/in_season_draft_pick/admin_test.exs
+++ b/test/lib/ex338/in_season_draft_pick/admin_test.exs
@@ -15,8 +15,7 @@ defmodule Ex338.InSeasonDraftPick.AdminTest do
       assert [
         {:update_pick, {:update, changeset, []}},
         {:update_position, {:update, old_pos_changeset, []}},
-        {:new_position, {:insert, new_pos_changeset, []}},
-        {:email, {:run, _function}}
+        {:new_position, {:insert, new_pos_changeset, []}}
       ] = Multi.to_list(multi)
 
       assert changeset.valid?
@@ -33,8 +32,7 @@ defmodule Ex338.InSeasonDraftPick.AdminTest do
       assert [
         {:update_pick, {:update, changeset, []}},
         {:update_position, {:update, old_pos_changeset, []}},
-        {:new_position, {:insert, _new_pos_changeset, []}},
-        {:email, {:run, _function}}
+        {:new_position, {:insert, _new_pos_changeset, []}}
       ] = Multi.to_list(multi)
 
       refute changeset.valid?

--- a/web/controllers/in_season_draft_pick_controller.ex
+++ b/web/controllers/in_season_draft_pick_controller.ex
@@ -1,7 +1,7 @@
 defmodule Ex338.InSeasonDraftPickController do
   use Ex338.Web, :controller
 
-  alias Ex338.{InSeasonDraftPick, Authorization}
+  alias Ex338.{InSeasonDraftPick, Authorization, Commish}
 
   import Canary.Plugs
 
@@ -31,6 +31,7 @@ defmodule Ex338.InSeasonDraftPickController do
     case InSeasonDraftPick.Store.draft_player(pick, params) do
       {:ok,  %{update_pick: pick}} ->
         league_id = pick.draft_pick_asset.fantasy_team.fantasy_league_id
+        Commish.InSeasonDraftEmail.send_update(league_id)
 
         conn
         |> put_flash(:info, "Draft pick successfully submitted.")


### PR DESCRIPTION
* Moved function that sends email notification out of Ecto multi transaction for 
* Failed email shouldn't cause the transaction to fail
* Draft can still go on if email service is down
* Closes #287