### PR TITLE
Add winnings_adj to FantasyTeam

### DIFF
--- a/lib/ex338/fantasy_team/standings.ex
+++ b/lib/ex338/fantasy_team/standings.ex
@@ -38,12 +38,12 @@ defmodule Ex338.FantasyTeam.Standings do
     end
   end
 
-  def calculate_all_winnings(%{roster_positions: positions,
-    champ_with_events_results: results}) do
+  def calculate_all_winnings(%{winnings_adj: winnings_adj,
+    roster_positions: positions, champ_with_events_results: results}) do
       player_winnings = calculate_position_winnings(positions)
       champ_with_events_winnings = calculate_winnings_from_results(results)
 
-      player_winnings + champ_with_events_winnings
+      player_winnings + champ_with_events_winnings + winnings_adj
   end
 
   defp calculate_position_winnings(positions) do

--- a/priv/repo/migrations/20170528152505_add_winnings_adj_to_fantasy_team.exs
+++ b/priv/repo/migrations/20170528152505_add_winnings_adj_to_fantasy_team.exs
@@ -1,0 +1,9 @@
+defmodule Ex338.Repo.Migrations.AddWinningsAdjToFantasyTeam do
+  use Ecto.Migration
+
+  def change do
+    alter table(:fantasy_teams) do
+      add :winnings_adj, :float, default: 0
+    end
+  end
+end

--- a/priv/repo/migrations/20170528153600_change_winnings_dues_in_fantasy_team.exs
+++ b/priv/repo/migrations/20170528153600_change_winnings_dues_in_fantasy_team.exs
@@ -1,0 +1,17 @@
+defmodule Ex338.Repo.Migrations.ChangeWinningsDuesInFantasyTeam do
+  use Ecto.Migration
+
+  def up do
+    alter table(:fantasy_teams) do
+      modify :dues_paid, :float, default: 0
+      modify :winnings_received, :float, default: 0
+    end
+  end
+
+  def down do
+    alter table(:fantasy_teams) do
+      modify :dues_paid, :decimal, default: 0
+      modify :winnings_received, :decimal, default: 0
+    end
+  end
+end

--- a/test/controllers/fantasy_league_controller_test.exs
+++ b/test/controllers/fantasy_league_controller_test.exs
@@ -22,9 +22,10 @@ defmodule Ex338.FantasyLeagueControllerTest do
   describe "show/2" do
     test "shows league and lists all fantasy teams", %{conn: conn} do
       league = insert(:fantasy_league)
-      team_1 = insert(:fantasy_team, team_name: "Brown", fantasy_league: league)
+      team_1 = insert(:fantasy_team, team_name: "Brown", fantasy_league: league,
+       winnings_adj: 20.00)
       team_2 = insert(:fantasy_team, team_name: "Axel", fantasy_league: league,
-       dues_paid: 100)
+       dues_paid: 100.00)
       player = insert(:fantasy_player)
       insert(:roster_position, fantasy_team: team_1, fantasy_player: player,
         status: "active")
@@ -39,6 +40,7 @@ defmodule Ex338.FantasyLeagueControllerTest do
       assert String.contains?(conn.resp_body, team_2.team_name)
       assert String.contains?(conn.resp_body, "100")
       assert String.contains?(conn.resp_body, "16.0")
+      assert String.contains?(conn.resp_body, "70.0")
     end
   end
 end

--- a/test/controllers/fantasy_team_controller_test.exs
+++ b/test/controllers/fantasy_team_controller_test.exs
@@ -23,7 +23,8 @@ defmodule Ex338.FantasyTeamControllerTest do
     test "shows fantasy team info and players' table", %{conn: conn} do
       league = insert(:fantasy_league)
       team = insert(:fantasy_team, team_name: "Brown", fantasy_league: league,
-                                   winnings_received: 75, dues_paid: 100)
+                                   winnings_received: 75.00, dues_paid: 100.00,
+                                   winnings_adj: 10.00)
       insert(:owner, user: conn.assigns.current_user, fantasy_team: team)
 
       sport = insert(:sports_league)

--- a/test/lib/ex338/fantasy_team/standings_test.exs
+++ b/test/lib/ex338/fantasy_team/standings_test.exs
@@ -5,19 +5,19 @@ defmodule Ex338.FantasyTeam.StandingsTest do
   describe "get_points_winnings_for_teams/1" do
     test "calculates points/winnings for teams & adds to FantasyTeam struct" do
       teams = [
-        %{team: "A", roster_positions: [
+        %{team: "A", winnings_adj: 0, roster_positions: [
           %{fantasy_player: %{championship_results: []}},
           %{fantasy_player: %{championship_results: []}},
           %{fantasy_player: %{championship_results: []}}],
           champ_with_events_results: []
         },
-        %{team: "B", roster_positions: [
+        %{team: "B", winnings_adj: 100, roster_positions: [
           %{fantasy_player: %{championship_results: [%{rank: 1, points: 8}]}},
           %{fantasy_player: %{championship_results: []}},
           %{fantasy_player: %{championship_results: [%{rank: 2, points: 5}]}}],
           champ_with_events_results: [%{rank: 1, points: 8.0, winnings: 25.00}]
         },
-        %{team: "C", roster_positions: [
+        %{team: "C", winnings_adj: 0, roster_positions: [
           %{fantasy_player: %{championship_results: []}},
           %{fantasy_player: %{championship_results: []}},
           %{fantasy_player: %{championship_results: [%{rank: 2, points: 5}]}}],
@@ -27,7 +27,7 @@ defmodule Ex338.FantasyTeam.StandingsTest do
 
       result = Standings.rank_points_winnings_for_teams(teams)
 
-      assert Enum.map(result, &(&1.winnings)) == [60, 10, 0]
+      assert Enum.map(result, &(&1.winnings)) == [160, 10, 0]
       assert Enum.map(result, &(&1.points)) == [21, 5, 0]
       assert Enum.map(result, &(&1.rank)) == [1, 2, 3]
       assert Enum.map(result, &(&1.team)) == ["B", "C", "A"]
@@ -37,7 +37,7 @@ defmodule Ex338.FantasyTeam.StandingsTest do
   describe "get_points_winnings/1" do
     test "calculates points/winnings and adds to FantasyTeam struct" do
       team =
-        %{roster_positions: [
+        %{winnings_adj: 100, roster_positions: [
           %{fantasy_player: %{championship_results: [%{rank: 1, points: 8}]}},
           %{fantasy_player: %{championship_results: []}},
           %{fantasy_player: %{championship_results: [%{rank: 2, points: 5}]}}],
@@ -49,7 +49,7 @@ defmodule Ex338.FantasyTeam.StandingsTest do
 
       result = Standings.update_points_winnings(team)
 
-      assert result.winnings == 70
+      assert result.winnings == 170
       assert result.points == 26
     end
   end

--- a/test/lib/ex338/fantasy_team/store_test.exs
+++ b/test/lib/ex338/fantasy_team/store_test.exs
@@ -74,7 +74,7 @@ defmodule Ex338.FantasyTeam.StoreTest do
     test "returns team with assocs and calculated fields" do
       league = insert(:fantasy_league)
       team = insert(:fantasy_team, team_name: "Brown", fantasy_league: league,
-                                   winnings_received: 75, dues_paid: 100)
+                                   winnings_received: 75.00, dues_paid: 100.00)
       user = insert_user(%{name: "Axel"})
       insert(:owner, user: user, fantasy_team: team)
 

--- a/web/admin/fantasy_team.ex
+++ b/web/admin/fantasy_team.ex
@@ -11,6 +11,7 @@ defmodule Ex338.ExAdmin.FantasyTeam do
         row :team_name
         row :waiver_position
         row :fantasy_league
+        row :winnings_adj
         row :dues_paid
         row :winnings_received
         row :commish_notes, type: :text

--- a/web/models/fantasy_team.ex
+++ b/web/models/fantasy_team.ex
@@ -8,8 +8,9 @@ defmodule Ex338.FantasyTeam do
   schema "fantasy_teams" do
     field :team_name, :string
     field :waiver_position, :integer
-    field :dues_paid, :decimal
-    field :winnings_received, :decimal
+    field :winnings_adj, :float, default: 0.0
+    field :dues_paid, :float, default: 0.0
+    field :winnings_received, :float, default: 0.0
     field :commish_notes, :string
     belongs_to :fantasy_league, Ex338.FantasyLeague
     has_many :champ_with_events_results, Ex338.ChampWithEventsResult
@@ -32,7 +33,8 @@ defmodule Ex338.FantasyTeam do
   def changeset(struct, params \\ %{}) do
     struct
     |> cast(params, [:team_name, :waiver_position, :fantasy_league_id,
-                     :dues_paid, :winnings_received, :commish_notes])
+                     :winnings_adj, :dues_paid, :winnings_received,
+                     :commish_notes])
     |> validate_required([:team_name, :waiver_position])
     |> validate_length(:team_name, max: 16)
   end


### PR DESCRIPTION
* Add winnings_adj to FantasyTeam
* Adjust winnings field in standings by this amount
* Enables commish to adjust displayed winnings
* May be used for overall champion or ties (eg Men's Tennis)
* Changed winnings_received and dues paid to floats for consistency
* Closes #194