### PR TITLE
Convert from Ecto.DateTime to Elixir DateTime

### DIFF
--- a/lib/ex338/calendar_assistant.ex
+++ b/lib/ex338/calendar_assistant.ex
@@ -1,27 +1,18 @@
 defmodule Ex338.CalendarAssistant do
-  @moduledoc false
-
-  def days_from_now(days) do
-    days = (86_400 * days)
-    now = Ecto.DateTime.utc
-          |> Ecto.DateTime.to_erl
-          |> Calendar.DateTime.from_erl!("UTC")
-
-    now
-    |> Calendar.DateTime.add!(days)
-    |> Calendar.DateTime.to_erl
-    |> Ecto.DateTime.from_erl
-  end
+  @moduledoc """
+  Functions to add days to a date
+  """
 
   def datetime_add_days(datetime, days) do
     days = (86_400 * days)
-    datetime = datetime
-               |> Ecto.DateTime.to_erl
-               |> Calendar.DateTime.from_erl!("UTC")
 
-    datetime
-    |> Calendar.DateTime.add!(days)
-    |> Calendar.DateTime.to_erl
-    |> Ecto.DateTime.from_erl
+    Calendar.DateTime.add!(datetime, days)
+  end
+
+  def days_from_now(days) do
+    days = (86_400 * days)
+    now = DateTime.utc_now
+
+    Calendar.DateTime.add!(now, days)
   end
 end

--- a/lib/ex338/championship.ex
+++ b/lib/ex338/championship.ex
@@ -10,9 +10,9 @@ defmodule Ex338.Championship do
   schema "championships" do
     field :title, :string
     field :category, :string
-    field :waiver_deadline_at, Ecto.DateTime
-    field :trade_deadline_at, Ecto.DateTime
-    field :championship_at, Ecto.DateTime
+    field :waiver_deadline_at, :utc_datetime
+    field :trade_deadline_at, :utc_datetime
+    field :championship_at, :utc_datetime
     field :year, :integer
     field :in_season_draft, :boolean
     belongs_to :sports_league, Ex338.SportsLeague

--- a/lib/ex338/in_season_draft_pick/admin.ex
+++ b/lib/ex338/in_season_draft_pick/admin.ex
@@ -52,7 +52,7 @@ defmodule Ex338.InSeasonDraftPick.Admin do
 
   defp update_position(multi, draft_pick) do
     params = %{
-      "released_at" => Ecto.DateTime.utc(),
+      "released_at" => DateTime.utc_now(),
       "status" => "drafted_pick"
     }
 
@@ -65,7 +65,7 @@ defmodule Ex338.InSeasonDraftPick.Admin do
       "fantasy_team_id" => draft_pick.draft_pick_asset.fantasy_team_id,
       "fantasy_player_id" => player_id,
       "position" => draft_pick.draft_pick_asset.position,
-      "active_at" => Ecto.DateTime.utc(),
+      "active_at" => DateTime.utc_now(),
       "status" => "active"
     }
 

--- a/lib/ex338/injured_reserve/admin.ex
+++ b/lib/ex338/injured_reserve/admin.ex
@@ -40,7 +40,7 @@ defmodule Ex338.InjuredReserve.Admin do
       %{
         "fantasy_team_id" => team_id,
         "fantasy_player_id" => player_id,
-        "active_at" => Ecto.DateTime.utc(),
+        "active_at" => DateTime.utc_now(),
         "position" => "Unassigned",
         "status" => "active"
       }

--- a/lib/ex338/roster_position.ex
+++ b/lib/ex338/roster_position.ex
@@ -19,8 +19,8 @@ defmodule Ex338.RosterPosition do
     field :position, :string
     belongs_to :fantasy_player, Ex338.FantasyPlayer
     field :status, :string
-    field :active_at, Ecto.DateTime
-    field :released_at, Ecto.DateTime
+    field :active_at, :utc_datetime
+    field :released_at, :utc_datetime
     has_many :championship_slots, Ex338.ChampionshipSlot
     has_many :in_season_draft_picks, Ex338.InSeasonDraftPick, foreign_key: :draft_pick_asset_id
 

--- a/lib/ex338/roster_position/season_ended.ex
+++ b/lib/ex338/roster_position/season_ended.ex
@@ -50,8 +50,8 @@ defmodule Ex338.RosterPosition.SeasonEnded do
   end
 
   defp compare_to_today(championship_date) do
-    now    = Ecto.DateTime.utc()
-    result = Ecto.DateTime.compare(championship_date, now)
+    now    = DateTime.utc_now()
+    result = DateTime.compare(championship_date, now)
 
     did_season_end?(result)
   end

--- a/lib/ex338/trade/admin.ex
+++ b/lib/ex338/trade/admin.ex
@@ -28,7 +28,7 @@ defmodule Ex338.Trade.Admin do
     params =
       %{
         "status" => "traded",
-        "released_at" => Ecto.DateTime.utc()
+        "released_at" => DateTime.utc_now()
       }
 
     Multi.update(multi, multi_name, RosterPosition.changeset(position, params))
@@ -48,7 +48,7 @@ defmodule Ex338.Trade.Admin do
       %{
         "fantasy_team_id" => team_id,
         "fantasy_player_id" => player_id,
-        "active_at" => Ecto.DateTime.utc(),
+        "active_at" => DateTime.utc_now(),
         "position" => "Unassigned",
         "status" => "active"
       }

--- a/lib/ex338_web/views/view_helpers.ex
+++ b/lib/ex338_web/views/view_helpers.ex
@@ -30,9 +30,7 @@ defmodule Ex338Web.ViewHelpers do
   end
 
   def short_date(date) do
-    date
-    |> Ecto.DateTime.to_erl
-    |> strftime!("%b %e, %Y")
+    strftime!(date, "%b %e, %Y")
   end
 
   def short_datetime_pst(%NaiveDateTime{} = date) do
@@ -44,8 +42,6 @@ defmodule Ex338Web.ViewHelpers do
 
   def short_datetime_pst(date) do
     date
-    |> Ecto.DateTime.to_erl
-    |> Calendar.DateTime.from_erl!("UTC")
     |> Calendar.DateTime.shift_zone!("America/Los_Angeles")
     |> strftime!("%b %e, %l:%M %p")
   end

--- a/lib/ex338_web/views/waiver_view.ex
+++ b/lib/ex338_web/views/waiver_view.ex
@@ -2,7 +2,7 @@ defmodule Ex338Web.WaiverView do
   use Ex338Web, :view
 
   def after_now?(date_time) do
-    case Ecto.DateTime.compare(date_time, Ecto.DateTime.utc) do
+    case DateTime.compare(date_time, DateTime.utc_now()) do
       :gt -> true
       :eq -> true
       :lt -> false
@@ -14,7 +14,7 @@ defmodule Ex338Web.WaiverView do
   end
 
   defp before_other_date?(date1, date2) do
-    case Ecto.DateTime.compare(date1, date2) do
+    case DateTime.compare(date1, date2) do
       :gt -> true
       :eq -> true
       :lt -> false

--- a/test/ex338/calendar_assistant_test.exs
+++ b/test/ex338/calendar_assistant_test.exs
@@ -4,24 +4,20 @@ defmodule Ex338.CalendarAssistantTest do
 
   describe "days_from_now/1" do
     test "returns a date a specified number of days from now" do
-      now = Ecto.DateTime.utc
+      now = DateTime.utc_now()
       yesterday = CalendarAssistant.days_from_now(-1)
       tomorrow  = CalendarAssistant.days_from_now(1)
 
-      assert Ecto.DateTime.compare(now, yesterday) == :gt #gained time
-      assert Ecto.DateTime.compare(now, tomorrow) == :lt  #lost time
+      assert DateTime.compare(now, yesterday) == :gt
+      assert DateTime.compare(now, tomorrow) == :lt
     end
   end
 
   describe "datetime_add_days/2" do
     test "returns a date a specified number of days from a given date" do
-      datetime = Ecto.DateTime.cast!(
-        %{day: 17, hour: 14, min: 0, month: 4, sec: 0, year: 2010}
-      )
-
-      five_days_later = Ecto.DateTime.cast!(
-        %{day: 22, hour: 14, min: 0, month: 4, sec: 0, year: 2010}
-      )
+      datetime = DateTime.from_naive!(~N[2016-05-24 13:26:08.003], "Etc/UTC")
+      five_days_later =
+        DateTime.from_naive!(~N[2016-05-29 13:26:08.003], "Etc/UTC")
 
       assert CalendarAssistant.datetime_add_days(datetime, 5) == five_days_later
     end

--- a/test/ex338/championship_repo_test.exs
+++ b/test/ex338/championship_repo_test.exs
@@ -4,17 +4,15 @@ defmodule Ex338.ChampionshipRepoTest do
 
   describe "earliest_first/1" do
     test "return championships with earliest date first" do
-      insert(:championship,
+      insert(
+        :championship,
         title: "A",
-        championship_at: Ecto.DateTime.cast!(
-          %{day: 17, hour: 0, min: 0, month: 6, sec: 0, year: 2017}
-        )
+        championship_at: CalendarAssistant.days_from_now(10)
       )
-      insert(:championship,
+      insert(
+        :championship,
         title: "B",
-        championship_at: Ecto.DateTime.cast!(
-          %{day: 17, hour: 0, min: 0, month: 5, sec: 0, year: 2017}
-        )
+        championship_at: CalendarAssistant.days_from_now(5)
       )
 
       query =

--- a/test/ex338/championship_test.exs
+++ b/test/ex338/championship_test.exs
@@ -1,15 +1,16 @@
 defmodule Ex338.ChampionshipTest do
   use Ex338.DataCase
 
-  alias Ex338.Championship
+  alias Ex338.{Championship, CalendarAssistant}
 
   @valid_attrs %{
     category: "some content",
-    championship_at: %{day: 17, hour: 14, min: 0, month: 4, sec: 0, year: 2010},
+    championship_at: CalendarAssistant.days_from_now(100),
     title: "some content",
-    trade_deadline_at: %{day: 17, hour: 14, min: 0, month: 4, sec: 0, year: 2010},
-    waiver_deadline_at: %{day: 17, hour: 14, min: 0, month: 4, sec: 0, year: 2010},
-    sports_league_id: 1, year: 2017
+    trade_deadline_at: CalendarAssistant.days_from_now(15),
+    waiver_deadline_at: CalendarAssistant.days_from_now(15),
+    sports_league_id: 1,
+    year: 2017
   }
   @invalid_attrs %{}
 

--- a/test/ex338/roster_position_repo_test.exs
+++ b/test/ex338/roster_position_repo_test.exs
@@ -29,7 +29,7 @@ defmodule Ex338.RosterPositionRepoTest do
                                           fantasy_team:   team,
                                           status:         "active",
                                           released_at:    nil)
-      released_at = Ecto.DateTime.utc
+      released_at = DateTime.utc_now()
       status = "dropped"
 
       RosterPosition
@@ -40,7 +40,7 @@ defmodule Ex338.RosterPositionRepoTest do
       result = Repo.get!(RosterPosition, position.id)
 
       assert result.status == "dropped"
-      assert result.released_at == Ecto.DateTime.utc
+      assert DateTime.diff(result.released_at, DateTime.utc_now()) < 1
     end
   end
 

--- a/test/ex338/waiver/waiver_admin_test.exs
+++ b/test/ex338/waiver/waiver_admin_test.exs
@@ -7,21 +7,21 @@ defmodule Ex338.WaiverAdminTest do
     fantasy_team_id:          1,
     add_fantasy_player_id:    2,
     drop_fantasy_player_id:   3,
-    process_at: Ecto.DateTime.utc,
+    process_at: DateTime.utc_now(),
   }
 
   @drop_waiver %Waiver{
     fantasy_team_id:          1,
     add_fantasy_player_id:    nil,
     drop_fantasy_player_id:   3,
-    process_at: Ecto.DateTime.utc,
+    process_at: DateTime.utc_now(),
   }
 
   @add_waiver %Waiver{
     fantasy_team_id:          1,
     add_fantasy_player_id:    2,
     drop_fantasy_player_id:   nil,
-    process_at: Ecto.DateTime.utc,
+    process_at: DateTime.utc_now(),
   }
 
   describe "update_waiver_status/3" do

--- a/test/ex338_web/views/view_helpers_test.exs
+++ b/test/ex338_web/views/view_helpers_test.exs
@@ -136,8 +136,7 @@ defmodule Ex338Web.ViewHelpersViewTest do
 
   describe "short_date/1" do
     test "formats DateTime struct into short date" do
-      date = Ecto.DateTime.cast!(
-        %{day: 16, hour: 0, min: 0, month: 9, sec: 0, year: 2017})
+      date = DateTime.from_naive!(~N[2017-09-16 22:30:00.000], "Etc/UTC")
 
       result = ViewHelpers.short_date(date)
 
@@ -147,8 +146,7 @@ defmodule Ex338Web.ViewHelpersViewTest do
 
   describe "short_datetime_pst/1" do
     test "formats DateTime struct into short datetime in PST" do
-      date = Ecto.DateTime.cast!(
-        %{day: 16, hour: 22, min: 30, month: 9, sec: 0, year: 2017})
+      date = DateTime.from_naive!(~N[2017-09-16 22:30:00.000], "Etc/UTC")
 
       result = ViewHelpers.short_datetime_pst(date)
 

--- a/test/ex338_web/views/waiver_view_test.exs
+++ b/test/ex338_web/views/waiver_view_test.exs
@@ -6,18 +6,18 @@ defmodule Ex338Web.WaiverViewTest do
   describe "sort_most_recent/1" do
     test "returns struct sorted by most recent first" do
       waivers = [
-        %{fantasy_team: "a",
-          process_at: Ecto.DateTime.cast!(
-            %{day: 1, hour: 14, min: 0, month: 4, sec: 0, year: 2010}
-          )},
-        %{fantasy_team: "c",
-          process_at: Ecto.DateTime.cast!(
-            %{day: 3, hour: 14, min: 0, month: 5, sec: 0, year: 2010}
-          )},
-        %{fantasy_team: "b",
-          process_at: Ecto.DateTime.cast!(
-            %{day: 2, hour: 14, min: 0, month: 4, sec: 0, year: 2010}
-          )},
+        %{
+          fantasy_team: "a",
+          process_at: CalendarAssistant.days_from_now(-5)
+        },
+        %{
+          fantasy_team: "c",
+          process_at: CalendarAssistant.days_from_now(-1)
+        },
+        %{
+          fantasy_team: "b",
+          process_at: CalendarAssistant.days_from_now(-3)
+        },
       ]
 
       result = WaiverView.sort_most_recent(waivers)
@@ -33,9 +33,7 @@ defmodule Ex338Web.WaiverViewTest do
 
       assert result == true
     end
-    test "returns true if date is equal to now" do
-      assert WaiverView.after_now?(Ecto.DateTime.utc)
-    end
+
     test "returns false if date is before now" do
       three_days_before_now = CalendarAssistant.days_from_now(-3)
 
@@ -53,6 +51,7 @@ defmodule Ex338Web.WaiverViewTest do
 
       assert result == "*****"
     end
+
     test "displays name if sport is not hiding waiver claims" do
       player = %{player_name: "Michigan", sports_league: %{hide_waivers: false}}
 

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -200,7 +200,7 @@ defmodule Ex338.Factory do
       fantasy_team:          build(:fantasy_team),
       add_fantasy_player:    build(:fantasy_player),
       drop_fantasy_player:   build(:fantasy_player),
-      process_at: Ecto.DateTime.utc,
+      process_at: DateTime.utc_now(),
     }
   end
 end


### PR DESCRIPTION
* Convert from Ecto.DateTime to Elixir DateTime
* Ecto.DateTime is deprecated
* Update view_helpers for Elixir DateTime
* Update CalendarAssistant for Elixir DateTime
* Update Ecto Schemas to use :utc_datetime
* Some changes were required because DateTime is more precise
* Closes #256