### PR TITLE
Add team id to owner's team select in admin site

### DIFF
--- a/lib/ex338/coherence/user.ex
+++ b/lib/ex338/coherence/user.ex
@@ -17,6 +17,8 @@ defmodule Ex338.User do
     timestamps()
   end
 
+  def alphabetical(query), do: from u in query, order_by: u.name
+
   def changeset(model, params \\ %{}) do
     model
     |> cast(params, [:name, :email, :admin] ++ coherence_fields())

--- a/lib/ex338_web/admin/owner.ex
+++ b/lib/ex338_web/admin/owner.ex
@@ -2,7 +2,17 @@ defmodule Ex338Web.ExAdmin.Owner do
   @moduledoc false
   use ExAdmin.Register
 
+  alias Ex338.{FantasyTeam, Repo, User}
+
   register_resource Ex338.Owner do
 
+    form owner do
+      inputs do
+        input owner, :fantasy_team,
+          collection: Repo.all(FantasyTeam.alphabetical(FantasyTeam)),
+          fields: [:team_name, :id]
+        input owner, :user, collection: Repo.all(User.alphabetical(User))
+      end
+    end
   end
 end

--- a/test/ex338/user_repo_test.exs
+++ b/test/ex338/user_repo_test.exs
@@ -12,6 +12,22 @@ defmodule Ex338.UserRepoTest do
     end
   end
 
+  describe "alphabetical/1" do
+    test "returns users in alphabetical order by name" do
+      insert(:user, name: "B")
+      insert(:user, name: "A")
+      insert(:user, name: "C")
+
+      result =
+        User
+        |> User.alphabetical
+        |> Repo.all
+        |> Enum.map(&(&1.name))
+
+      assert result == ["A", "B", "C"]
+    end
+  end
+
   describe "my_fantasy_league/1" do
     test "returns newest fantasy leageu for a user" do
       league_1 = insert(:fantasy_league, year: 2016)


### PR DESCRIPTION
* It was not possible to tell which team was the most recent
* Attempted to add year, but ExAdmin won't let you use that field
* Tried virtual field on FantasyTeam without success
* Best way to distinguish I could figure out is with the id
* Ordered users alphabetically by name
* Closes #325