### PR TITLE
Fix IR bug when returning to encumbered position

### DIFF
--- a/lib/ex338/injured_reserve/admin.ex
+++ b/lib/ex338/injured_reserve/admin.ex
@@ -26,10 +26,15 @@ defmodule Ex338.InjuredReserve.Admin do
   end
 
   defp update_ir_position(multi, {:remove, _ir}, %{ir: position}) do
+    [unassigned] = RosterPosition.default_position()
+
     Multi.update(
       multi,
       :ir_to_active,
-      RosterPosition.changeset(position, %{"status" => "active"})
+      RosterPosition.changeset(
+        position,
+        %{"status" => "active", "position" => unassigned}
+      )
     )
   end
 

--- a/test/ex338/injured_reserve/admin_test.exs
+++ b/test/ex338/injured_reserve/admin_test.exs
@@ -57,6 +57,7 @@ defmodule Ex338.InjuredReserve.AdminTest do
 
       assert ir_changeset.valid?
       assert pos_changeset.valid?
+      assert pos_changeset.changes.position == "Unassigned"
       assert drop_pos_changeset.valid?
     end
   end

--- a/test/ex338/injured_reserve/store_test.exs
+++ b/test/ex338/injured_reserve/store_test.exs
@@ -58,9 +58,13 @@ defmodule Ex338.InjuredReserve.StoreTest do
       team = insert(:fantasy_team, fantasy_league: league)
       player_a = insert(:fantasy_player)
       player_b = insert(:fantasy_player)
+      player_c = insert(:fantasy_player)
       insert(:roster_position, fantasy_team: team, fantasy_player: player_a,
-       status: "injured_reserve")
-      insert(:roster_position, fantasy_team: team, fantasy_player: player_b)
+       position: "WTn", status: "injured_reserve")
+      insert(:roster_position, fantasy_team: team, fantasy_player: player_b,
+       position: "Flex1")
+      insert(:roster_position, fantasy_team: team, fantasy_player: player_c,
+       position: "WTn")
       ir = insert(:injured_reserve, remove_player: player_a, fantasy_team: team,
         replacement_player: player_b)
 
@@ -68,7 +72,7 @@ defmodule Ex338.InjuredReserve.StoreTest do
 
       assert ir.status == "approved"
       positions = Repo.all(Ex338.RosterPosition)
-      assert Enum.count(positions) == 2
+      assert Enum.count(positions) == 3
     end
 
     test "returns error on remove if position is not found for replacement" do


### PR DESCRIPTION
* Fix IR bug when returning to encumbered position
* Returning an IR to a filled position resulted in a bug
* Database saw a player in the position and returned an error
* Returning to "Unassigned" will eliminate error
* Add test to reproduce error
* Closes #310