### PR TITLE
Add feature to vote for trades through the site

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -47,6 +47,7 @@ config :ex_admin,
     Ex338Web.ExAdmin.Waiver,
     Ex338Web.ExAdmin.Trade,
     Ex338Web.ExAdmin.TradeLineItem,
+    Ex338Web.ExAdmin.TradeVote,
     Ex338Web.ExAdmin.DraftPick,
     Ex338Web.ExAdmin.InSeasonDraftPick,
   ]

--- a/lib/ex338/coherence/user.ex
+++ b/lib/ex338/coherence/user.ex
@@ -12,6 +12,7 @@ defmodule Ex338.User do
     field :admin, :boolean
     has_many :owners, Ex338.Owner
     has_many :submitted_trades, Ex338.Trade, foreign_key: :submitted_by_user_id
+    has_many :trade_votes, Ex338.TradeVote
     has_many :fantasy_teams, through: [:owners, :fantasy_team]
     coherence_schema()
 

--- a/lib/ex338/fantasy_team.ex
+++ b/lib/ex338/fantasy_team.ex
@@ -25,6 +25,7 @@ defmodule Ex338.FantasyTeam do
     has_many :trade_gains, Ex338.TradeLineItem, foreign_key: :gaining_team_id
     has_many :trade_losses, Ex338.TradeLineItem, foreign_key: :losing_team_id
     has_many :submitted_trades, Ex338.Trade, foreign_key: :submitted_by_team_id
+    has_many :trade_votes, Ex338.TradeVote
 
     timestamps()
   end

--- a/lib/ex338/trade.ex
+++ b/lib/ex338/trade.ex
@@ -13,6 +13,7 @@ defmodule Ex338.Trade do
     belongs_to :submitted_by_team, Ex338.FantasyTeam
     belongs_to :submitted_by_user, Ex338.User
     has_many :trade_line_items, TradeLineItem
+    has_many :trade_votes, Ex338.TradeVote
 
     timestamps()
   end

--- a/lib/ex338/trade/store.ex
+++ b/lib/ex338/trade/store.ex
@@ -9,6 +9,7 @@ defmodule Ex338.Trade.Store do
     |> Trade.preload_assocs
     |> Trade.newest_first
     |> Repo.all
+    |> Trade.count_votes
   end
 
   def build_new_changeset() do

--- a/lib/ex338/trade_vote.ex
+++ b/lib/ex338/trade_vote.ex
@@ -1,0 +1,26 @@
+defmodule Ex338.TradeVote do
+  @moduledoc false
+  use Ecto.Schema
+  import Ecto.Changeset
+  alias Ex338.TradeVote
+
+  schema "trade_votes" do
+    field :approve, :boolean, default: true
+    belongs_to :trade, Ex338.Trade
+    belongs_to :fantasy_team, Ex338.FantasyTeam
+    belongs_to :user, Ex338.User
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(%TradeVote{} = trade_vote, attrs) do
+    trade_vote
+    |> cast(attrs, [:approve, :trade_id, :fantasy_team_id, :user_id])
+    |> validate_required([:approve, :trade_id, :fantasy_team_id, :user_id])
+    |> unique_constraint(:trade,
+         name: :trade_votes_trade_id_fantasy_team_id_index,
+         message: "Team has already voted"
+       )
+  end
+end

--- a/lib/ex338/trade_vote/store.ex
+++ b/lib/ex338/trade_vote/store.ex
@@ -1,0 +1,11 @@
+defmodule Ex338.TradeVote.Store do
+  @moduledoc false
+
+  alias Ex338.{TradeVote, Repo}
+
+  def create_vote(attrs) do
+    %TradeVote{}
+    |> TradeVote.changeset(attrs)
+    |> Repo.insert
+  end
+end

--- a/lib/ex338/user/store.ex
+++ b/lib/ex338/user/store.ex
@@ -1,7 +1,7 @@
 defmodule Ex338.User.Store do
   @moduledoc false
 
-  alias Ex338.{User, Owner, Repo}
+  alias Ex338.{FantasyTeam, User, Owner, Repo}
 
   def get_admin_emails() do
     Repo.all(User.admin_emails)
@@ -11,5 +11,12 @@ defmodule Ex338.User.Store do
     admins = get_admin_emails()
     owners = Owner.Store.get_email_recipients_for_league(league_id)
     Enum.uniq(owners ++ admins)
+  end
+
+  def preload_team_by_league(%User{} = user, league_id) do
+    Repo.preload(
+      user,
+      [fantasy_teams: FantasyTeam.by_league(FantasyTeam, league_id)]
+    )
   end
 end

--- a/lib/ex338_web/admin/trade_vote.ex
+++ b/lib/ex338_web/admin/trade_vote.ex
@@ -1,0 +1,9 @@
+defmodule Ex338Web.ExAdmin.TradeVote do
+  @moduledoc false
+
+  use ExAdmin.Register
+
+  register_resource Ex338.TradeVote do
+
+  end
+end

--- a/lib/ex338_web/controllers/trade_controller.ex
+++ b/lib/ex338_web/controllers/trade_controller.ex
@@ -16,6 +16,11 @@ defmodule Ex338Web.TradeController do
   def index(conn, %{"fantasy_league_id" => league_id}) do
     league = FantasyLeague.Store.get(league_id)
 
+    user_with_team =
+      User.Store.preload_team_by_league(conn.assigns.current_user, league_id)
+
+    conn = assign(conn, :current_user, user_with_team)
+
     render(
       conn,
       "index.html",

--- a/lib/ex338_web/controllers/trade_vote_controller.ex
+++ b/lib/ex338_web/controllers/trade_vote_controller.ex
@@ -28,13 +28,19 @@ defmodule Ex338Web.TradeVoteController do
              conn, :index, team.fantasy_league_id
            ))
 
-      {:error, _changeset} ->
+      {:error, changeset} ->
         conn
-        |> put_flash(:error, "There was an error with your vote.")
+        |> put_flash(:error, "#{parse_errors(changeset.errors)}")
         |> redirect(to: fantasy_league_trade_path(
              conn, :index, team.fantasy_league_id
            ))
     end
   end
-end
 
+  defp parse_errors(errors) do
+    case Keyword.get(errors, :trade) do
+      nil -> inspect(errors)
+      {trade_error, _} -> trade_error
+    end
+  end
+end

--- a/lib/ex338_web/controllers/trade_vote_controller.ex
+++ b/lib/ex338_web/controllers/trade_vote_controller.ex
@@ -1,0 +1,40 @@
+defmodule Ex338Web.TradeVoteController do
+  use Ex338Web, :controller
+
+  alias Ex338.{FantasyTeam, TradeVote}
+  alias Ex338Web.{Authorization}
+
+  plug :load_and_authorize_resource, model: FantasyTeam, only: [:create],
+    preload: [:owners, :fantasy_league], persisted: true,
+    id_name: "fantasy_team_id",
+    unauthorized_handler: {Authorization, :handle_unauthorized}
+
+  import Canary.Plugs
+
+  def create(conn, %{"fantasy_team_id" => _id, "trade_vote" => vote_params}) do
+    team = conn.assigns.fantasy_team
+
+    vote_params =
+      vote_params
+      |> Map.put("user_id", conn.assigns.current_user.id)
+      |> Map.put("fantasy_team_id", team.id)
+
+    case TradeVote.Store.create_vote(vote_params) do
+      {:ok, _vote} ->
+
+        conn
+        |> put_flash(:info, "Vote successfully submitted.")
+        |> redirect(to: fantasy_league_trade_path(
+             conn, :index, team.fantasy_league_id
+           ))
+
+      {:error, _changeset} ->
+        conn
+        |> put_flash(:error, "There was an error with your vote.")
+        |> redirect(to: fantasy_league_trade_path(
+             conn, :index, team.fantasy_league_id
+           ))
+    end
+  end
+end
+

--- a/lib/ex338_web/emails/trade_email.ex
+++ b/lib/ex338_web/emails/trade_email.ex
@@ -5,11 +5,11 @@ defmodule Ex338Web.TradeEmail do
 
   @commish {"338 Commish", "no-reply@338admin.com"}
 
-  def new(_conn, league, trade, recipients) do
+  def new(conn, league, trade, recipients) do
     new()
     |> to(recipients)
     |> from(@commish)
     |> subject("New 338 Trade for Approval")
-    |> render_body("new_trade.html", %{league: league, trade: trade})
+    |> render_body("new_trade.html", %{conn: conn, league: league, trade: trade})
   end
 end

--- a/lib/ex338_web/router.ex
+++ b/lib/ex338_web/router.ex
@@ -57,6 +57,7 @@ defmodule Ex338Web.Router do
     resources "/fantasy_teams", FantasyTeamController, only: [:show, :edit, :update] do
         resources "/waivers", WaiverController, only: [:new, :create]
         resources "/trades", TradeController, only: [:new, :create]
+        resources "/trade_votes", TradeVoteController, only: [:create]
     end
 
     resources "/draft_picks", DraftPickController, only: [:edit, :update]

--- a/lib/ex338_web/templates/email/new_trade.html.eex
+++ b/lib/ex338_web/templates/email/new_trade.html.eex
@@ -14,5 +14,5 @@
   no-response during the voting period will be considered an approval. 
 </p> 
 <h3>
-  Please ensure Brown is included in your reply as this is an auto-generated email.
+  Please got to the <%= link "list of trades", to: fantasy_league_trade_url(@conn, :index, @league.id) %> to place your vote.
 </h3>

--- a/lib/ex338_web/templates/trade/index.html.eex
+++ b/lib/ex338_web/templates/trade/index.html.eex
@@ -9,9 +9,7 @@
           <th>Date</th>
           <th>Trade</th>
           <th>Status</th>
-          <%= if @current_user && @current_user.admin == true do %>
-            <th>Action</th>
-          <% end %>
+          <th>Vote</th>
         </tr>
       </thead>
       <tbody>
@@ -38,21 +36,36 @@
               </ul>
             </td>
             <td>
-              <%= trade.status %>
-            </td>
-            <%= if @current_user && @current_user.admin == true do %>
-              <td>
-              <%= if trade.status == "Pending" do %>
-                <%= link "Approve", 
+              <p><%= trade.status %></p>
+              <%= if @current_user && @current_user.admin == true do %>
+                <%= if trade.status == "Pending" do %>
+                  <%= link "Approve", 
                   to: fantasy_league_trade_admin_path(
                     @conn, :update, @fantasy_league.id, trade.id, %{"status" => "Approved"}
                   ),
                   data: [confirm: "Please confirm to approve trade"], class: "btn", method: :patch
                 %>
               <% end %>
-              </td>
             <% end %>
-          </tr>
+          </td>
+          <td>
+            <p>Yes: <%= trade.yes_votes %> No: <%= trade.no_votes %></p>
+          <%= if allow_vote?(trade, @current_user) do %>
+            <%= link "Yes", 
+            to: fantasy_team_trade_vote_path(
+              @conn, :create, get_team(@current_user), %{"trade_vote" => %{"approve" => "true", "trade_id" => trade.id}}
+            ),
+            data: [confirm: "Please confirm vote"], class: "btn", method: :post
+          %>
+            <%= link "No", 
+            to: fantasy_team_trade_vote_path(
+              @conn, :create, get_team(@current_user), %{"trade_vote" => %{"approve" => "false", "trade_id" => trade.id}}
+            ),
+            data: [confirm: "Please confirm vote"], class: "btn", method: :post
+          %>
+        <% end %>
+        </td>
+        </tr>
         <% end %>
       </tbody>
     </table>

--- a/lib/ex338_web/views/trade_view.ex
+++ b/lib/ex338_web/views/trade_view.ex
@@ -1,3 +1,25 @@
 defmodule Ex338Web.TradeView do
   use Ex338Web, :view
+
+  def allow_vote?(
+    %{status: "Pending", trade_votes: votes},
+    %{fantasy_teams: [team]}
+  ) do
+    team_has_not_voted?(votes, team)
+  end
+
+  def allow_vote?(_trade, _current_user), do: false
+
+  def get_team(%{fantasy_teams: [team]}), do: team
+
+  def get_team(%{fantasy_teams: []}), do: :no_team
+
+  ## Helpers
+
+  # allow_vote?
+
+  def team_has_not_voted?(votes, team) do
+    !Enum.any?(votes, &(&1.fantasy_team_id) == team.id)
+  end
+
 end

--- a/priv/repo/migrations/20171203155647_create_trade_votes.exs
+++ b/priv/repo/migrations/20171203155647_create_trade_votes.exs
@@ -1,0 +1,18 @@
+defmodule Ex338.Repo.Migrations.CreateTradeVotes do
+  use Ecto.Migration
+
+  def change do
+    create table(:trade_votes) do
+      add :approve, :boolean, default: true, null: false
+      add :trade_id, references(:trades, on_delete: :delete_all)
+      add :fantasy_team_id, references(:fantasy_teams, on_delete: :nilify_all)
+      add :user_id, references(:users, on_delete: :nilify_all)
+
+      timestamps()
+    end
+
+    create index(:trade_votes, [:trade_id])
+    create index(:trade_votes, [:fantasy_team_id])
+    create index(:trade_votes, [:user_id])
+  end
+end

--- a/priv/repo/migrations/20171203180919_create_unique_index_for_trade_vote.exs
+++ b/priv/repo/migrations/20171203180919_create_unique_index_for_trade_vote.exs
@@ -1,0 +1,11 @@
+defmodule Ex338.Repo.Migrations.CreateUniqueIndexForTradeVote do
+  use Ecto.Migration
+
+  def up do
+    create unique_index(:trade_votes, [:trade_id, :fantasy_team_id])
+  end
+
+  def down do
+    drop unique_index(:trade_votes, [:trade_id, :fantasy_team_id])
+  end
+end

--- a/test/ex338/trade_repo_test.exs
+++ b/test/ex338/trade_repo_test.exs
@@ -36,11 +36,14 @@ defmodule Ex338.TradeRepoTest do
       player = insert(:fantasy_player, sports_league: sport)
       team_a = insert(:fantasy_team)
       team_b = insert(:fantasy_team)
+      team_c = insert(:fantasy_team)
+      user = insert(:user)
       trade = insert(:trade)
       insert(:trade_line_item, trade: trade, fantasy_player: player,
         gaining_team: team_a, losing_team: team_b)
+      insert(:trade_vote, trade: trade, fantasy_team: team_c, user: user)
 
-      %{trade_line_items: [line_item]} =
+      %{trade_line_items: [line_item], trade_votes: [vote]} =
         Trade
         |> Trade.preload_assocs
         |> Repo.one
@@ -48,6 +51,7 @@ defmodule Ex338.TradeRepoTest do
       assert line_item.fantasy_player.sports_league.id == sport.id
       assert line_item.gaining_team.id == team_a.id
       assert line_item.losing_team.id == team_b.id
+      assert vote.fantasy_team.id == team_c.id
     end
   end
 

--- a/test/ex338/trade_test.exs
+++ b/test/ex338/trade_test.exs
@@ -1,7 +1,7 @@
 defmodule Ex338.TradeTest do
   use Ex338.DataCase, async: true
 
-  alias Ex338.Trade
+  alias Ex338.{Trade, TradeVote}
 
   describe "changeset/2" do
     @valid_attrs %{}
@@ -15,6 +15,60 @@ defmodule Ex338.TradeTest do
     test "changeset invalid when incorrect status option provided" do
       changeset = Trade.changeset(%Trade{}, @invalid_attrs)
       refute changeset.valid?
+    end
+  end
+
+  describe "count_votes/1" do
+    test "counts votes and updates a list of trades" do
+      trades = [
+        %Trade{
+          trade_votes: [
+            %TradeVote{approve: false},
+            %TradeVote{approve: true},
+            %TradeVote{approve: false}
+          ]
+        },
+        %Trade{
+          trade_votes: [
+            %TradeVote{approve: false},
+            %TradeVote{approve: true},
+            %TradeVote{approve: true}
+          ]
+        }
+      ]
+
+      [trade1, trade2] = Trade.count_votes(trades)
+
+      assert trade1.yes_votes == 1
+      assert trade1.no_votes == 2
+      assert trade2.yes_votes == 2
+      assert trade2.no_votes == 1
+    end
+
+    test "counts votes and updates trade" do
+      trade = %Trade{
+        trade_votes: [
+          %TradeVote{approve: false},
+          %TradeVote{approve: true},
+          %TradeVote{approve: false}
+        ]
+      }
+
+      result = Trade.count_votes(trade)
+
+      assert result.yes_votes == 1
+      assert result.no_votes == 2
+    end
+
+    test "counts votes and updates trade with 0 votes if none submitted" do
+      trade = %Trade{
+        trade_votes: []
+      }
+
+      result = Trade.count_votes(trade)
+
+      assert result.yes_votes == 0
+      assert result.no_votes == 0
     end
   end
 

--- a/test/ex338/trade_vote/store_test.exs
+++ b/test/ex338/trade_vote/store_test.exs
@@ -1,0 +1,26 @@
+defmodule Ex338.TradeVote.StoreTest do
+  use Ex338.DataCase
+  alias Ex338.TradeVote.Store
+
+  describe "create_vote/1" do
+    test "creates a new vote from params" do
+      trade = insert(:trade)
+      team = insert(:fantasy_team)
+      user = insert(:user)
+      attrs =
+        %{
+          "trade_id" => trade.id,
+          "fantasy_team_id" => team.id,
+          "user_id" => user.id,
+          "approve" => true,
+        }
+
+      {:ok, result} = Store.create_vote(attrs)
+
+      assert result.trade_id == trade.id
+      assert result.fantasy_team_id == team.id
+      assert result.user_id == user.id
+      assert result.approve == true
+    end
+  end
+end

--- a/test/ex338/trade_vote_test.exs
+++ b/test/ex338/trade_vote_test.exs
@@ -1,0 +1,44 @@
+defmodule Ex338.TradeVoteTest do
+  use Ex338.DataCase, async: true
+
+  alias Ex338.TradeVote
+
+  describe "changeset/2" do
+    @valid_attrs %{
+      trade_id: 1, fantasy_team_id: 2, user_id: 3, approve: false
+    }
+    test "valid with required attributes" do
+      changeset = TradeVote.changeset(%TradeVote{}, @valid_attrs)
+      assert changeset.valid?
+    end
+
+    @invalid_attrs %{}
+    test "invalid without required attributes" do
+      changeset = TradeVote.changeset(%TradeVote{}, @invalid_attrs)
+      refute changeset.valid?
+    end
+
+    test "invalid if team already voted" do
+      trade = insert(:trade)
+      team = insert(:fantasy_team)
+      user = insert(:user)
+      other_user = insert(:user)
+      insert(:trade_vote, user: user, trade: trade, fantasy_team: team)
+      attrs =
+        %{
+          trade_id: trade.id,
+          fantasy_team_id: team.id,
+          user_id: other_user.id,
+          approve: false,
+        }
+
+      changeset = TradeVote.changeset(%TradeVote{}, attrs)
+      {:error, changeset} = Repo.insert(changeset)
+
+      refute changeset.valid?
+      assert changeset.errors == [
+        trade: {"Team has already voted", []}
+      ]
+    end
+  end
+end

--- a/test/ex338/user/store_test.exs
+++ b/test/ex338/user/store_test.exs
@@ -31,4 +31,34 @@ defmodule Ex338.User.StoreTest do
       assert Enum.count(result) == 2
     end
   end
+
+  describe "preload_team_by_league/2" do
+    test "preloads fantasy team matching fantasy league" do
+      user = insert(:user)
+      league = insert(:fantasy_league)
+      team = insert(:fantasy_team, fantasy_league: league)
+      insert(:owner, fantasy_team: team, user: user)
+      other_league = insert(:fantasy_league)
+      other_team = insert(:fantasy_team, fantasy_league: other_league)
+      insert(:owner, fantasy_team: other_team, user: user)
+
+      result = User.Store.preload_team_by_league(user, league.id)
+      %{fantasy_teams: [team_result]} = result
+
+      assert team_result.id == team.id
+    end
+
+    test "empty list when no fantasy team in league" do
+      user = insert(:user)
+      league = insert(:fantasy_league)
+      team = insert(:fantasy_team, fantasy_league: league)
+      insert(:owner, fantasy_team: team, user: user)
+      other_league = insert(:fantasy_league)
+      _other_team = insert(:fantasy_team, fantasy_league: other_league)
+
+      result = User.Store.preload_team_by_league(user, other_league.id)
+
+      assert %{fantasy_teams: []} = result
+    end
+  end
 end

--- a/test/ex338_web/controllers/trade_vote_controller_test.exs
+++ b/test/ex338_web/controllers/trade_vote_controller_test.exs
@@ -1,0 +1,53 @@
+defmodule Ex338Web.TradeVoteControllerTest do
+  use Ex338Web.ConnCase
+  alias Ex338.{TradeVote, Repo, User}
+
+  setup %{conn: conn} do
+    user = %User{name: "test", email: "test@example.com", id: 1}
+    {:ok, conn: assign(conn, :current_user, user), user: user}
+  end
+
+  describe "create/2" do
+    test "create a trade vote and redirect", %{conn: conn} do
+      league = insert(:fantasy_league)
+      team = insert(:fantasy_team, fantasy_league: league)
+      team_b = insert(:fantasy_team, fantasy_league: league)
+      team_c = insert(:fantasy_team, fantasy_league: league)
+      user = conn.assigns.current_user
+      other_user = insert(:user)
+      insert(:owner, fantasy_team: team, user: user)
+      insert(:owner, fantasy_team: team, user: other_user)
+      sports_league = insert(:sports_league)
+      insert(:league_sport, fantasy_league: league, sports_league: sports_league)
+      player_a = insert(:fantasy_player, sports_league: sports_league)
+      player_b = insert(:fantasy_player, sports_league: sports_league)
+      insert(:roster_position, fantasy_player: player_a, fantasy_team: team_b)
+      insert(:roster_position, fantasy_player: player_b, fantasy_team: team_c)
+      trade =
+        insert(:trade, submitted_by_team: team_b, submitted_by_user: other_user)
+      insert(
+        :trade_line_item,
+        gaining_team: team_c, fantasy_player: player_a, losing_team: team_b
+      )
+      insert(
+        :trade_line_item,
+        gaining_team: team_b, fantasy_player: player_b, losing_team: team_c
+      )
+      attrs = %{trade_id: trade.id, approve: true}
+
+      conn = post(
+        conn,
+        fantasy_team_trade_vote_path(conn, :create, team.id, trade_vote: attrs)
+      )
+
+      result =
+        Repo.get_by!(TradeVote, %{trade_id: trade.id, fantasy_team_id: team.id})
+
+      assert result.fantasy_team_id == team.id
+      assert result.user_id == user.id
+      assert result.approve == true
+      assert redirected_to(conn) ==
+        fantasy_league_trade_path(conn, :index, league.id)
+    end
+  end
+end

--- a/test/ex338_web/controllers/trade_vote_controller_test.exs
+++ b/test/ex338_web/controllers/trade_vote_controller_test.exs
@@ -48,6 +48,81 @@ defmodule Ex338Web.TradeVoteControllerTest do
       assert result.approve == true
       assert redirected_to(conn) ==
         fantasy_league_trade_path(conn, :index, league.id)
+      assert get_flash(conn, :info) == "Vote successfully submitted."
+    end
+
+    test "doesn't create if team already voted and redirects", %{conn: conn} do
+      league = insert(:fantasy_league)
+      team = insert(:fantasy_team, fantasy_league: league)
+      team_b = insert(:fantasy_team, fantasy_league: league)
+      team_c = insert(:fantasy_team, fantasy_league: league)
+      user = conn.assigns.current_user
+      co_owner = insert(:user)
+      other_user = insert(:user)
+      insert(:owner, fantasy_team: team, user: user)
+      insert(:owner, fantasy_team: team, user: co_owner)
+      insert(:owner, fantasy_team: team_b, user: other_user)
+      sports_league = insert(:sports_league)
+      insert(:league_sport, fantasy_league: league, sports_league: sports_league)
+      player_a = insert(:fantasy_player, sports_league: sports_league)
+      player_b = insert(:fantasy_player, sports_league: sports_league)
+      insert(:roster_position, fantasy_player: player_a, fantasy_team: team_b)
+      insert(:roster_position, fantasy_player: player_b, fantasy_team: team_c)
+      trade =
+        insert(:trade, submitted_by_team: team_b, submitted_by_user: other_user)
+      insert(
+        :trade_line_item,
+        gaining_team: team_c, fantasy_player: player_a, losing_team: team_b
+      )
+      insert(
+        :trade_line_item,
+        gaining_team: team_b, fantasy_player: player_b, losing_team: team_c
+      )
+      insert(:trade_vote, user: co_owner, trade: trade, fantasy_team: team)
+      attrs = %{trade_id: trade.id, approve: true}
+
+      conn = post(
+        conn,
+        fantasy_team_trade_vote_path(conn, :create, team.id, trade_vote: attrs)
+      )
+
+      assert html_response(conn, 302) =~ ~r/redirected/
+      assert get_flash(conn, :error) == "Team has already voted"
+      assert Enum.count(Repo.all(TradeVote)) == 1
+    end
+
+    test "redirects to root if user is not owner", %{conn: conn} do
+      league = insert(:fantasy_league)
+      team = insert(:fantasy_team, fantasy_league: league)
+      team_b = insert(:fantasy_team, fantasy_league: league)
+      team_c = insert(:fantasy_team, fantasy_league: league)
+      other_user = insert(:user)
+      insert(:owner, fantasy_team: team, user: other_user)
+      sports_league = insert(:sports_league)
+      insert(:league_sport, fantasy_league: league, sports_league: sports_league)
+      player_a = insert(:fantasy_player, sports_league: sports_league)
+      player_b = insert(:fantasy_player, sports_league: sports_league)
+      insert(:roster_position, fantasy_player: player_a, fantasy_team: team_b)
+      insert(:roster_position, fantasy_player: player_b, fantasy_team: team_c)
+      trade =
+        insert(:trade, submitted_by_team: team_b, submitted_by_user: other_user)
+      insert(
+        :trade_line_item,
+        gaining_team: team_c, fantasy_player: player_a, losing_team: team_b
+      )
+      insert(
+        :trade_line_item,
+        gaining_team: team_b, fantasy_player: player_b, losing_team: team_c
+      )
+      attrs = %{trade_id: trade.id, approve: true}
+
+      conn = post(
+        conn,
+        fantasy_team_trade_vote_path(conn, :create, team.id, trade_vote: attrs)
+      )
+
+      assert html_response(conn, 302) =~ ~r/redirected/
+      assert get_flash(conn, :error) == "You can't access that page!"
     end
   end
 end

--- a/test/ex338_web/views/trade_view_test.exs
+++ b/test/ex338_web/views/trade_view_test.exs
@@ -1,0 +1,98 @@
+defmodule Ex338Web.TradeViewTest do
+  use Ex338Web.ConnCase, async: true
+
+  alias Ex338Web.TradeView
+
+  describe "allow_vote?/2" do
+    test "returns true if team can still vote" do
+      trade =
+        %{
+          status: "Pending",
+          trade_votes: [
+            %{fantasy_team_id: 1},
+            %{fantasy_team_id: 2}
+          ]
+        }
+
+      current_user = %{fantasy_teams: [%{id: 3}]}
+
+      result = TradeView.allow_vote?(trade, current_user)
+
+      assert result == true
+    end
+
+    test "returns false if team has voted" do
+      trade =
+        %{
+          status: "Pending",
+          trade_votes: [
+            %{fantasy_team_id: 1},
+            %{fantasy_team_id: 2}
+          ]
+        }
+
+      current_user = %{fantasy_teams: [%{id: 2}]}
+
+      result = TradeView.allow_vote?(trade, current_user)
+
+      assert result == false
+    end
+
+    test "returns false if trade is no longer pending" do
+      trade =
+        %{
+          status: "Approved",
+          trade_votes: [
+            %{fantasy_team_id: 1},
+            %{fantasy_team_id: 2}
+          ]
+        }
+
+      current_user = %{fantasy_teams: [%{id: 3}]}
+
+      result = TradeView.allow_vote?(trade, current_user)
+
+      assert result == false
+    end
+
+    test "returns false if user doesn't own teams in the league" do
+      trade =
+        %{
+          status: "Pending",
+          trade_votes: [
+            %{fantasy_team_id: 1},
+            %{fantasy_team_id: 2}
+          ]
+        }
+
+      current_user = %{fantasy_teams: []}
+
+      result = TradeView.allow_vote?(trade, current_user)
+
+      assert result == false
+    end
+  end
+
+  describe "get_team/1" do
+    test "returns fantasy team from current user" do
+      current_user =
+        %{
+          fantasy_teams: [
+            %{id: 1}
+          ]
+        }
+
+      result = TradeView.get_team(current_user)
+
+      assert result.id == 1
+    end
+
+    test "returns :no_team if there are no teams" do
+      current_user = %{fantasy_teams: []}
+
+      result = TradeView.get_team(current_user)
+
+      assert result == :no_team
+    end
+  end
+end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -152,6 +152,15 @@ defmodule Ex338.Factory do
     }
   end
 
+  def trade_vote_factory do
+    %Ex338.TradeVote{
+      trade: build(:trade),
+      fantasy_team: build(:fantasy_team),
+      user: build(:user),
+      approve: true,
+    }
+  end
+
   def sports_league_factory do
     %Ex338.SportsLeague{
       league_name: sequence(:league_name, &"League ##{&1}"),


### PR DESCRIPTION
* Will enable league to submit trade vote through site
* Both team and user are tracked to handle double votes from team
* See #373