### PR TITLE
Add link to Slack invite on home page

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -7,7 +7,8 @@ use Mix.Config
 
 # General application configuration
 config :ex338,
-  ecto_repos: [Ex338.Repo]
+  ecto_repos: [Ex338.Repo],
+  slack_invite_url: System.get_env("SLACK_INVITE_URL")
 
 # Configures the endpoint
 config :ex338, Ex338Web.Endpoint,

--- a/lib/ex338_web/templates/page/index.html.eex
+++ b/lib/ex338_web/templates/page/index.html.eex
@@ -1,7 +1,9 @@
 <div class="jumbotron">
   <h2><%= gettext "Welcome to %{name}", name: "the 338 Challenge!" %></h2>
   <h4>League-wide Announcements</h4>
-  <p>Dues are $200 for Division A, $225 for Division B, and $250 for Division C. Payment due by 1 Dec 2017.</p>
-  <p>Pay the commissioner at <a href="https://www.paypal.me/cubman9">https://www.paypal.me/cubman9</a> or Venmo: Ryan-Brown-104</p>
-  <p>To send a check, message the commish for his address</p>
+  <br>
+  <p>
+    League messsages, trash talk, trade discussions, etc. are done in the Slack channel.  <b>Click
+      <a href=<%= Application.get_env(:ex338, :slack_invite_url) %>>here</a> to request a Slack invite.<b>
+  </p>
 </div>


### PR DESCRIPTION
* Add link to Slack invite on home page
* Use environmental variable, so can easily update through Heroku
* Invite link expires after 30 days
* Closes #389