### PR TITLE
Update DraftQueue to drafted when team makes pick

### DIFF
--- a/lib/ex338/draft_pick/draft_admin.ex
+++ b/lib/ex338/draft_pick/draft_admin.ex
@@ -9,6 +9,7 @@ defmodule Ex338.DraftPick.DraftAdmin do
     |> update_draft_pick(draft_pick, params)
     |> new_roster_position(draft_pick, params)
     |> unavailable_draft_queues(draft_pick, params)
+    |> drafted_draft_queues(draft_pick, params)
   end
 
   ## Helpers
@@ -48,6 +49,22 @@ defmodule Ex338.DraftPick.DraftAdmin do
       multi,
       :unavailable_draft_queues,
       DraftQueue.Admin.update_unavailable_from_pick(updated_draft_pick),
+      [],
+      returning: true
+    )
+  end
+
+  defp drafted_draft_queues(
+    multi,
+    draft_pick,
+    %{"fantasy_player_id" => player_id}
+  ) do
+    updated_draft_pick = %{draft_pick | fantasy_player_id: player_id}
+
+    Multi.update_all(
+      multi,
+      :drafted_draft_queues,
+      DraftQueue.Admin.update_drafted_from_pick(updated_draft_pick),
       [],
       returning: true
     )

--- a/lib/ex338/draft_queue.ex
+++ b/lib/ex338/draft_queue.ex
@@ -26,6 +26,10 @@ defmodule Ex338.DraftQueue do
     from q in query, where: q.fantasy_player_id == ^fantasy_player_id
   end
 
+  def by_team(query, fantasy_team_id) do
+    from q in query, where: q.fantasy_team_id == ^fantasy_team_id
+  end
+
   @doc false
   def changeset(%DraftQueue{} = draft_queue, attrs \\ %{}) do
     draft_queue
@@ -34,6 +38,10 @@ defmodule Ex338.DraftQueue do
       [:order, :fantasy_team_id, :fantasy_player_id, :status]
     )
     |> validate_required([:order, :fantasy_team_id, :fantasy_player_id])
+  end
+
+  def except_team(query, fantasy_team_id) do
+    from q in query, where: q.fantasy_team_id != ^fantasy_team_id
   end
 
   def only_pending(query) do
@@ -48,6 +56,10 @@ defmodule Ex338.DraftQueue do
 
   def status_options() do
     Enum.filter(DraftQueueStatusEnum.__valid_values__(), &(is_binary(&1)))
+  end
+
+  def update_to_drafted(query) do
+    from q in query, update: [set: [status: "drafted"]]
   end
 
   def update_to_unavailable(query) do

--- a/lib/ex338/draft_queue/admin.ex
+++ b/lib/ex338/draft_queue/admin.ex
@@ -3,30 +3,62 @@ defmodule Ex338.DraftQueue.Admin do
 
   alias Ex338.{DraftPick, DraftQueue, InSeasonDraftPick}
 
+  def update_drafted_from_pick(
+    %DraftPick{
+      fantasy_player_id: player_id,
+      fantasy_team_id: team_id,
+      fantasy_team: %{fantasy_league_id: league_id}
+    }
+  ), do: do_update_drafted(player_id, team_id, league_id)
+
+  def update_drafted_from_pick(
+    %InSeasonDraftPick{
+      drafted_player_id: player_id,
+      draft_pick_asset: %{
+        fantasy_team_id: team_id,
+        fantasy_team: %{fantasy_league_id: league_id}
+      }
+    }
+  ), do: do_update_drafted(player_id, team_id, league_id)
+
   def update_unavailable_from_pick(
     %DraftPick{
       fantasy_player_id: player_id,
+      fantasy_team_id: team_id,
       fantasy_team: %{fantasy_league_id: league_id}
     }
-  ), do: do_update_unavailable(player_id, league_id)
+  ), do: do_update_unavailable(player_id, team_id, league_id)
 
   def update_unavailable_from_pick(
     %InSeasonDraftPick{
       drafted_player_id: player_id,
       draft_pick_asset: %{
+        fantasy_team_id: team_id,
         fantasy_team: %{fantasy_league_id: league_id}
       }
     }
-  ), do: do_update_unavailable(player_id, league_id)
+  ), do: do_update_unavailable(player_id, team_id, league_id)
 
   ## Helpers
 
   ## update_unavailable_from_pick
 
-  def do_update_unavailable(fantasy_player_id, fantasy_league_id) do
+  def do_update_drafted(player_id, team_id, league_id) do
     DraftQueue
-    |> DraftQueue.by_player(fantasy_player_id)
-    |> DraftQueue.by_league(fantasy_league_id)
+    |> DraftQueue.by_player(player_id)
+    |> DraftQueue.by_team(team_id)
+    |> DraftQueue.by_league(league_id)
+    |> DraftQueue.only_pending
+    |> DraftQueue.update_to_drafted
+  end
+
+  ## update_unavailable_from_pick
+
+  def do_update_unavailable(player_id, drafting_team_id, league_id) do
+    DraftQueue
+    |> DraftQueue.by_player(player_id)
+    |> DraftQueue.except_team(drafting_team_id)
+    |> DraftQueue.by_league(league_id)
     |> DraftQueue.only_pending
     |> DraftQueue.update_to_unavailable
   end

--- a/lib/ex338/in_season_draft_pick/admin.ex
+++ b/lib/ex338/in_season_draft_pick/admin.ex
@@ -16,6 +16,7 @@ defmodule Ex338.InSeasonDraftPick.Admin do
     |> update_position(draft_pick)
     |> new_position(draft_pick, params)
     |> unavailable_draft_queues(draft_pick, params)
+    |> drafted_draft_queues(draft_pick, params)
   end
 
   ## Helpers
@@ -91,6 +92,22 @@ defmodule Ex338.InSeasonDraftPick.Admin do
       multi,
       :unavailable_draft_queues,
       DraftQueue.Admin.update_unavailable_from_pick(updated_draft_pick),
+      [],
+      returning: true
+    )
+  end
+
+  defp drafted_draft_queues(
+    multi,
+    draft_pick,
+    %{"drafted_player_id" => player_id}
+  ) do
+    updated_draft_pick = %{draft_pick | drafted_player_id: player_id}
+
+    Multi.update_all(
+      multi,
+      :drafted_draft_queues,
+      DraftQueue.Admin.update_drafted_from_pick(updated_draft_pick),
       [],
       returning: true
     )

--- a/test/ex338/draft_pick/draft_admin_test.exs
+++ b/test/ex338/draft_pick/draft_admin_test.exs
@@ -13,7 +13,8 @@ defmodule Ex338.DraftPick.DraftAdminTest do
       assert [
         {:draft_pick, {:update, _draft_pick_changeset, []}},
         {:roster_position, {:insert, _roster_position_changeset, []}},
-        {:unavailable_draft_queues, {:update_all, _, [], returning: true}}
+        {:unavailable_draft_queues, {:update_all, _, [], returning: true}},
+        {:drafted_draft_queues, {:update_all, _, [], returning: true}}
       ] = Ecto.Multi.to_list(multi)
     end
   end

--- a/test/ex338/draft_queue/admin_test.exs
+++ b/test/ex338/draft_queue/admin_test.exs
@@ -3,8 +3,8 @@ defmodule Ex338.DraftQueue.AdminTest do
 
   alias Ex338.{DraftQueue.Admin, DraftQueue}
 
-  describe "update_unavailable_from_pick/1" do
-    test "updates pending draft queues from a draft pick" do
+  describe "update_drafted_from_pick/1" do
+    test "updates pending draft queues to drafted from a draft pick" do
       league = insert(:fantasy_league)
       sport = insert(:sports_league)
       insert(:league_sport, fantasy_league: league, sports_league: sport)
@@ -13,14 +13,6 @@ defmodule Ex338.DraftQueue.AdminTest do
 
       team = insert(:fantasy_team, fantasy_league: league)
       insert(:draft_queue, fantasy_team: team, fantasy_player: player)
-      team2 = insert(:fantasy_team, fantasy_league: league)
-      insert(:draft_queue, fantasy_team: team2, fantasy_player: player)
-      insert(
-        :draft_queue,
-        fantasy_team: team2,
-        fantasy_player: player,
-        status: :cancelled
-      )
 
       other_league = insert(:fantasy_league)
       insert(:league_sport, fantasy_league: other_league, sports_league: sport)
@@ -28,12 +20,25 @@ defmodule Ex338.DraftQueue.AdminTest do
       insert(:draft_queue, fantasy_team: other_team, fantasy_player: player)
 
       team_with_pick = insert(:fantasy_team, fantasy_league: league)
+      _cancelled_queue =
+        insert(
+          :draft_queue,
+          fantasy_team: team_with_pick,
+          fantasy_player: player,
+          status: :cancelled
+        )
+      _drafted_queue =
+        insert(
+          :draft_queue,
+          fantasy_team: team_with_pick,
+          fantasy_player: player
+        )
       draft_pick =
         insert(:draft_pick, fantasy_team: team_with_pick, fantasy_player: player)
 
       {num_updated, _updated_queues} =
         draft_pick
-        |> Admin.update_unavailable_from_pick
+        |> Admin.update_drafted_from_pick
         |> Repo.update_all([], returning: true)
 
       [q1, q2, q3, q4] =
@@ -41,14 +46,14 @@ defmodule Ex338.DraftQueue.AdminTest do
         |> Repo.all
         |> Enum.sort_by(&(&1.id))
 
-      assert num_updated == 2
-      assert q1.status == :unavailable
-      assert q2.status == :unavailable
+      assert num_updated == 1
+      assert q1.status == :pending
+      assert q2.status == :pending
       assert q3.status == :cancelled
-      assert q4.status == :pending
+      assert q4.status == :drafted
     end
 
-    test "updates pending draft queues from a inseason draft pick" do
+    test "updates pending draft queues to drafted from an inseason draft pick" do
       league = insert(:fantasy_league)
       sport = insert(:sports_league)
       insert(:league_sport, fantasy_league: league, sports_league: sport)
@@ -79,16 +84,65 @@ defmodule Ex338.DraftQueue.AdminTest do
           fantasy_team: team_with_pick,
           fantasy_player: pick_player
         )
+      insert(:draft_queue, fantasy_team: team_with_pick, fantasy_player: player)
       in_season_draft_pick =
         insert(:in_season_draft_pick, position: 1, draft_pick_asset: pick_asset,
           championship: championship, drafted_player: player)
 
       {num_updated, _updated_queues} =
         in_season_draft_pick
+        |> Admin.update_drafted_from_pick
+        |> Repo.update_all([], returning: true)
+
+      [q1, q2, q3, q4, q5] =
+        DraftQueue
+        |> Repo.all
+        |> Enum.sort_by(&(&1.id))
+
+      assert num_updated == 1
+      assert q1.status == :pending
+      assert q2.status == :pending
+      assert q3.status == :cancelled
+      assert q4.status == :pending
+      assert q5.status == :drafted
+    end
+  end
+
+  describe "update_unavailable_from_pick/1" do
+    test "updates pending draft queues from a draft pick" do
+      league = insert(:fantasy_league)
+      sport = insert(:sports_league)
+      insert(:league_sport, fantasy_league: league, sports_league: sport)
+      insert(:championship, sports_league: sport)
+      player = insert(:fantasy_player, sports_league: sport)
+
+      team = insert(:fantasy_team, fantasy_league: league)
+      insert(:draft_queue, fantasy_team: team, fantasy_player: player)
+      team2 = insert(:fantasy_team, fantasy_league: league)
+      insert(:draft_queue, fantasy_team: team2, fantasy_player: player)
+      insert(
+        :draft_queue,
+        fantasy_team: team2,
+        fantasy_player: player,
+        status: :cancelled
+      )
+
+      other_league = insert(:fantasy_league)
+      insert(:league_sport, fantasy_league: other_league, sports_league: sport)
+      other_team = insert(:fantasy_team, fantasy_league: other_league)
+      insert(:draft_queue, fantasy_team: other_team, fantasy_player: player)
+
+      team_with_pick = insert(:fantasy_team, fantasy_league: league)
+      insert(:draft_queue, fantasy_team: team_with_pick, fantasy_player: player)
+      draft_pick =
+        insert(:draft_pick, fantasy_team: team_with_pick, fantasy_player: player)
+
+      {num_updated, _updated_queues} =
+        draft_pick
         |> Admin.update_unavailable_from_pick
         |> Repo.update_all([], returning: true)
 
-      [q1, q2, q3, q4] =
+      [q1, q2, q3, q4, q5] =
         DraftQueue
         |> Repo.all
         |> Enum.sort_by(&(&1.id))
@@ -98,6 +152,61 @@ defmodule Ex338.DraftQueue.AdminTest do
       assert q2.status == :unavailable
       assert q3.status == :cancelled
       assert q4.status == :pending
+      assert q5.status == :pending
+    end
+
+    test "updates pending draft queues from an inseason draft pick" do
+      league = insert(:fantasy_league)
+      sport = insert(:sports_league)
+      insert(:league_sport, fantasy_league: league, sports_league: sport)
+      championship = insert(:championship, sports_league: sport)
+      player = insert(:fantasy_player, sports_league: sport)
+
+      team = insert(:fantasy_team, fantasy_league: league)
+      insert(:draft_queue, fantasy_team: team, fantasy_player: player)
+      team2 = insert(:fantasy_team, fantasy_league: league)
+      insert(:draft_queue, fantasy_team: team2, fantasy_player: player)
+      insert(
+        :draft_queue,
+        fantasy_team: team2,
+        fantasy_player: player,
+        status: :cancelled
+      )
+
+      other_league = insert(:fantasy_league)
+      insert(:league_sport, fantasy_league: other_league, sports_league: sport)
+      other_team = insert(:fantasy_team, fantasy_league: other_league)
+      insert(:draft_queue, fantasy_team: other_team, fantasy_player: player)
+
+      team_with_pick = insert(:fantasy_team, fantasy_league: league)
+      pick_player = insert(:fantasy_player, sports_league: sport)
+      pick_asset =
+        insert(
+          :roster_position,
+          fantasy_team: team_with_pick,
+          fantasy_player: pick_player
+        )
+      insert(:draft_queue, fantasy_team: team_with_pick, fantasy_player: player)
+      in_season_draft_pick =
+        insert(:in_season_draft_pick, position: 1, draft_pick_asset: pick_asset,
+          championship: championship, drafted_player: player)
+
+      {num_updated, _updated_queues} =
+        in_season_draft_pick
+        |> Admin.update_unavailable_from_pick
+        |> Repo.update_all([], returning: true)
+
+      [q1, q2, q3, q4, q5] =
+        DraftQueue
+        |> Repo.all
+        |> Enum.sort_by(&(&1.id))
+
+      assert num_updated == 2
+      assert q1.status == :unavailable
+      assert q2.status == :unavailable
+      assert q3.status == :cancelled
+      assert q4.status == :pending
+      assert q5.status == :pending
     end
   end
 end

--- a/test/ex338/in_season_draft_pick/admin_test.exs
+++ b/test/ex338/in_season_draft_pick/admin_test.exs
@@ -15,7 +15,8 @@ defmodule Ex338.InSeasonDraftPick.AdminTest do
         {:update_pick, {:update, changeset, []}},
         {:update_position, {:update, old_pos_changeset, []}},
         {:new_position, {:insert, new_pos_changeset, []}},
-        {:unavailable_draft_queues, {:update_all, _, [], returning: true}}
+        {:unavailable_draft_queues, {:update_all, _, [], returning: true}},
+        {:drafted_draft_queues, {:update_all, _, [], returning: true}}
       ] = Multi.to_list(multi)
 
       assert changeset.valid?
@@ -33,7 +34,8 @@ defmodule Ex338.InSeasonDraftPick.AdminTest do
         {:update_pick, {:update, changeset, []}},
         {:update_position, {:update, old_pos_changeset, []}},
         {:new_position, {:insert, _new_pos_changeset, []}},
-        {:unavailable_draft_queues, {:update_all, _, [], returning: true}}
+        {:unavailable_draft_queues, {:update_all, _, [], returning: true}},
+        {:drafted_draft_queues, {:update_all, _, [], returning: true}}
       ] = Multi.to_list(multi)
 
       refute changeset.valid?

--- a/test/ex338/in_season_draft_pick/store_test.exs
+++ b/test/ex338/in_season_draft_pick/store_test.exs
@@ -74,6 +74,7 @@ defmodule Ex338.InSeasonDraftPick.StoreTest do
       pick =
         insert(:in_season_draft_pick, position: 1, draft_pick_asset: pick_asset,
           championship: championship)
+      insert(:draft_queue, fantasy_team: team, fantasy_player: player)
       params = %{"drafted_player_id" => player.id}
 
       team2 = insert(:fantasy_team, fantasy_league: league)
@@ -85,7 +86,8 @@ defmodule Ex338.InSeasonDraftPick.StoreTest do
           update_pick: updated_pick,
           update_position: old_pos,
           new_position: new_pos,
-          unavailable_draft_queues: {1, [updated_queue]}
+          unavailable_draft_queues: {1, [updated_queue]},
+          drafted_draft_queues: {1, [drafted_queue]},
         }
       } = Store.draft_player(pick, params)
 
@@ -97,6 +99,7 @@ defmodule Ex338.InSeasonDraftPick.StoreTest do
       assert new_pos.position == pick_asset.position
       assert new_pos.status == "active"
       assert updated_queue.status == :unavailable
+      assert drafted_queue.status == :drafted
     end
 
     test "does not update and returns errors when invalid" do

--- a/test/ex338_web/controllers/draft_pick_controller_test.exs
+++ b/test/ex338_web/controllers/draft_pick_controller_test.exs
@@ -63,11 +63,14 @@ defmodule Ex338Web.DraftPickControllerTest do
       team = insert(:fantasy_team, team_name: "Brown", fantasy_league: league)
       insert(:owner, fantasy_team: team, user: conn.assigns.current_user)
       player = insert(:fantasy_player)
+      drafted_queue =
+        insert(:draft_queue, fantasy_team: team, fantasy_player: player)
       pick = insert(:draft_pick, draft_position: 1.01, fantasy_team: team,
                                  fantasy_league: league)
 
       team2 = insert(:fantasy_team, fantasy_league: league)
-      insert(:draft_queue, fantasy_team: team2, fantasy_player: player)
+      unavailable_queue =
+        insert(:draft_queue, fantasy_team: team2, fantasy_player: player)
 
       conn = patch conn, draft_pick_path(conn, :update, pick.id,
                draft_pick: %{fantasy_player_id: player.id})
@@ -75,7 +78,8 @@ defmodule Ex338Web.DraftPickControllerTest do
       assert redirected_to(conn) == fantasy_league_draft_pick_path(conn, :index,
                                                                    league.id)
       assert Repo.get!(DraftPick, pick.id).fantasy_player_id == player.id
-      assert Repo.one(DraftQueue).status == :unavailable
+      assert Repo.get!(DraftQueue, unavailable_queue.id).status == :unavailable
+      assert Repo.get!(DraftQueue, drafted_queue.id).status == :drafted
     end
 
     test "does not update and renders errors when invalid", %{conn: conn} do

--- a/test/ex338_web/controllers/in_season_draft_pick_controller_test.exs
+++ b/test/ex338_web/controllers/in_season_draft_pick_controller_test.exs
@@ -50,6 +50,8 @@ defmodule Ex338Web.InSeasonDraftPickControllerTest do
       championship = insert(:championship)
       pick_player = insert(:fantasy_player, draft_pick: true)
       player = insert(:fantasy_player, draft_pick: false)
+      drafted_queue =
+        insert(:draft_queue, fantasy_team: team, fantasy_player: player)
       pick_asset =
         insert(:roster_position, fantasy_team: team, fantasy_player: pick_player)
       pick =
@@ -57,7 +59,8 @@ defmodule Ex338Web.InSeasonDraftPickControllerTest do
           championship: championship)
 
       team2 = insert(:fantasy_team, fantasy_league: league)
-      insert(:draft_queue, fantasy_team: team2, fantasy_player: player)
+      unavailable_queue =
+        insert(:draft_queue, fantasy_team: team2, fantasy_player: player)
 
       conn = patch conn, in_season_draft_pick_path(conn, :update, pick.id,
                in_season_draft_pick: %{drafted_player_id: player.id})
@@ -65,7 +68,8 @@ defmodule Ex338Web.InSeasonDraftPickControllerTest do
       assert Repo.get!(InSeasonDraftPick, pick.id).drafted_player_id == player.id
       assert redirected_to(conn) ==
         fantasy_league_championship_path(conn, :show, league.id, championship.id)
-      assert Repo.one(DraftQueue).status == :unavailable
+      assert Repo.get!(DraftQueue, unavailable_queue.id).status == :unavailable
+      assert Repo.get!(DraftQueue, drafted_queue.id).status == :drafted
     end
 
     test "does not update and renders errors when invalid", %{conn: conn} do


### PR DESCRIPTION
* Team making pick should have queues updated to drafted
* Need to exclude the queues from being updated unavailable
* Add by_player/2 & update_to_drafted/1 to DraftQueue
* Add updated_drafted_from_pick/1 to DraftQueue.Admin
* Add except_team/1 to DraftQueue
* Update update_unavailable_from_pick/1 to exclude drafting team
* Add :drafted_draft_queues to Ecto.Multi in DraftPick.DraftAdmin
* Add InSeasonDraftPick to DraftQueue.Admin.update_drafted_from_pick/1
* Add :drafted_draft_queues to Ecto.Multi in InSeasonDraftPick.Admin
* Closes #399