### PR TITLE
Add add rankings to slots on FantasyTeam pages

### DIFF
--- a/assets/css/_fantasy_teams.scss
+++ b/assets/css/_fantasy_teams.scss
@@ -32,7 +32,7 @@
 
     td:nth-child(4),
     th:nth-child(4) {
-      text-align: center;
+      text-align: right;
     }
   }
 }
@@ -75,7 +75,7 @@
 
       td:nth-child(4),
       th:nth-child(4) {
-        text-align: center;
+        text-align: right;
       }
     }
 
@@ -95,6 +95,19 @@
     p {
       text-align: left;
     }
+  }
+}
+
+.fantasy-team-table {
+
+  th.points,
+  td.points {
+    text-align: right;
+  }
+
+  th.rank,
+  td.rank {
+    text-align: left;
   }
 }
 

--- a/lib/ex338/fantasy_team.ex
+++ b/lib/ex338/fantasy_team.ex
@@ -36,6 +36,13 @@ defmodule Ex338.FantasyTeam do
     from t in query, order_by: t.team_name
   end
 
+  def add_rankings_to_slot_results(slot_results) do
+    slot_results
+    |> Enum.group_by(&(&1.sport_abbrev))
+    |> Enum.map(&(calculate_rankings(&1)))
+    |> Enum.reduce([], fn(sport_slots, all_slots) -> all_slots ++ sport_slots end)
+  end
+
   def add_slot_results(slot_results, teams) when is_list(teams) do
     Enum.map(teams, &(add_slot_results(slot_results, &1)))
   end
@@ -210,6 +217,27 @@ defmodule Ex338.FantasyTeam do
   end
 
   ## Helpers
+
+  ## add_rankings_to_slot_results
+
+  defp calculate_rankings({_sport_abbrev, slot_results}) do
+    slot_results
+    |> sort_slots_by_points
+    |> add_rank_to_slots
+  end
+
+  defp sort_slots_by_points(slot_results) do
+    Enum.sort(slot_results, &(&1.points >= &2.points))
+  end
+
+  defp add_rank_to_slots(slot_results) do
+    {teams, _} =
+      Enum.map_reduce slot_results, 1, fn(slot, acc) ->
+        {Map.put(slot, :rank, acc), acc + 1}
+      end
+
+    teams
+  end
 
   ## add_slot_results
 

--- a/lib/ex338/fantasy_team/store.ex
+++ b/lib/ex338/fantasy_team/store.ex
@@ -109,12 +109,14 @@ defmodule Ex338.FantasyTeam.Store do
   ) do
     league_id
     |> get_slot_results_for_league
+    |> FantasyTeam.add_rankings_to_slot_results
     |> FantasyTeam.add_slot_results(teams)
   end
 
-  def load_slot_results(%FantasyTeam{} = team) do
-    team
-    |> get_slot_results_for_team
+  def load_slot_results(%FantasyTeam{fantasy_league_id: league_id} = team) do
+    league_id
+    |> get_slot_results_for_league
+    |> FantasyTeam.add_rankings_to_slot_results
     |> FantasyTeam.add_slot_results(team)
   end
 
@@ -138,13 +140,6 @@ defmodule Ex338.FantasyTeam.Store do
   defp get_slot_results_for_league(fantasy_league_id) do
     FantasyTeam
     |> FantasyTeam.by_league(fantasy_league_id)
-    |> FantasyTeam.sum_slot_points
-    |> Repo.all
-  end
-
-  defp get_slot_results_for_team(%FantasyTeam{} = team) do
-    FantasyTeam
-    |> FantasyTeam.find_team(team.id)
     |> FantasyTeam.sum_slot_points
     |> Repo.all
   end

--- a/lib/ex338_web/templates/fantasy_team/champ_slots_table.html.eex
+++ b/lib/ex338_web/templates/fantasy_team/champ_slots_table.html.eex
@@ -3,7 +3,8 @@
     <tr>
       <th>Sport</th>
       <th>Slot</th>
-      <th>Points</th>
+      <th class="rank">Current Rank</th>
+      <th class="points">Points</th>
     </tr>
   </thead>
   <tbody>
@@ -11,7 +12,8 @@
       <tr>
         <td><%= result.sport_abbrev %></td>
         <td><%= result.slot %></td>
-        <td><%= result.points %></td>
+        <td class="rank"><%= result.rank %></td>
+        <td class="points"><%= result.points %></td>
       </tr>
     <% end %>
   </tbody>

--- a/lib/ex338_web/templates/fantasy_team/champ_with_events_table.html.eex
+++ b/lib/ex338_web/templates/fantasy_team/champ_with_events_table.html.eex
@@ -2,16 +2,18 @@
   <thead>
     <tr>
       <th>Sport</th>
-      <th>Final Rank</th>
-      <th>Points</th>
+      <th></th>
+      <th class="rank">Final Rank</th>
+      <th class="points">Points</th>
     </tr>
   </thead>
   <tbody>
     <%= for result <- @fantasy_team.champ_with_events_results do %>
       <tr>
         <td><%= result.championship.title %></td>
-        <td><%= result.rank %></td>
-        <td><%= result.points %></td>
+        <td></td>
+        <td class="rank"><%= result.rank %></td>
+        <td class="points"><%= result.points %></td>
       </tr>
     <% end %>
   </tbody>

--- a/test/ex338/fantasy_team/store_test.exs
+++ b/test/ex338/fantasy_team/store_test.exs
@@ -173,7 +173,7 @@ defmodule Ex338.FantasyTeam.StoreTest do
     end
   end
 
-  describe "load_slot_results_for_league/2" do
+  describe "load_slot_results/1" do
     test "returns slots for teams in league with points summed" do
       league = insert(:fantasy_league)
       league2 = insert(:fantasy_league)
@@ -262,11 +262,13 @@ defmodule Ex338.FantasyTeam.StoreTest do
       assert result1.points == 13
       assert result1.slot == 1
       assert result1.sport_abbrev == sport.abbrev
+      assert result1.rank == 1
 
       assert result2.fantasy_team_id == team.id
       assert result2.points == 5
       assert result2.slot == 2
       assert result2.sport_abbrev == sport.abbrev
+      assert result1.rank == 1
     end
 
     test "returns slots for a team in a league with points summed" do
@@ -354,11 +356,13 @@ defmodule Ex338.FantasyTeam.StoreTest do
       assert result1.points == 13
       assert result1.slot == 1
       assert result1.sport_abbrev == sport.abbrev
+      assert result1.rank == 1
 
       assert result2.fantasy_team_id == team.id
       assert result2.points == 5
       assert result2.slot == 2
       assert result2.sport_abbrev == sport.abbrev
+      assert result2.rank == 2
     end
   end
 

--- a/test/ex338/fantasy_team_repo_test.exs
+++ b/test/ex338/fantasy_team_repo_test.exs
@@ -23,6 +23,26 @@ defmodule Ex338.FantasyTeamRepoTest do
     end
   end
 
+  describe "add_rankings_to_slot_results" do
+    test "adds rankings for current slot results to FantasyTeam struct" do
+      slots = [
+        %{fantasy_team_id: 1, points: 13, slot: 1, sport_abbrev: "A"},
+        %{fantasy_team_id: 1, points: 5, slot: 2, sport_abbrev: "A"},
+        %{fantasy_team_id: 2, points: 8, slot: 1, sport_abbrev: "A"},
+        %{fantasy_team_id: 2, points: 8, slot: 1, sport_abbrev: "B"}
+      ]
+
+      results = FantasyTeam.add_rankings_to_slot_results(slots)
+
+      assert results == [
+        %{fantasy_team_id: 1, points: 13, slot: 1, sport_abbrev: "A", rank: 1},
+        %{fantasy_team_id: 2, points: 8, slot: 1, sport_abbrev: "A", rank: 2},
+        %{fantasy_team_id: 1, points: 5, slot: 2, sport_abbrev: "A", rank: 3},
+        %{fantasy_team_id: 2, points: 8, slot: 1, sport_abbrev: "B", rank: 1}
+      ]
+    end
+  end
+
   describe "alphabetical/1" do
     test "returns fantasy teams in alphabetical order" do
       insert(:fantasy_team, team_name: "a")


### PR DESCRIPTION
* Add FantasyTeam function to add rankings to slots
* Add rank to champ_slots_table in FantasyTeam
* Update css and table alignment
* Closes #403