### PR TITLE
Allow max flex spots to be set by commish

### DIFF
--- a/lib/ex338/fantasy_league.ex
+++ b/lib/ex338/fantasy_league.ex
@@ -8,6 +8,7 @@ defmodule Ex338.FantasyLeague do
     field(:year, :integer)
     field(:division, :string)
     field(:navbar_display, FantasyLeagueNavbarDisplayEnum, default: "primary")
+    field(:max_flex_spots, :integer)
     belongs_to(:sport_draft, Ex338.SportsLeague)
     has_many(:fantasy_teams, Ex338.FantasyTeam)
     has_many(:draft_picks, Ex338.DraftPick)
@@ -21,7 +22,14 @@ defmodule Ex338.FantasyLeague do
   """
   def changeset(struct, params \\ %{}) do
     struct
-    |> cast(params, [:fantasy_league_name, :year, :division, :sport_draft_id, :navbar_display])
+    |> cast(params, [
+      :fantasy_league_name,
+      :year,
+      :division,
+      :sport_draft_id,
+      :navbar_display,
+      :max_flex_spots
+    ])
     |> validate_required([:fantasy_league_name, :year, :division])
   end
 

--- a/lib/ex338/fantasy_team/store.ex
+++ b/lib/ex338/fantasy_team/store.ex
@@ -99,6 +99,7 @@ defmodule Ex338.FantasyTeam.Store do
   def get_team_with_active_positions(team_id) do
     FantasyTeam
     |> FantasyTeam.find_team(team_id)
+    |> FantasyTeam.with_league()
     |> FantasyTeam.preload_all_active_positions()
     |> Repo.one()
   end

--- a/lib/ex338/fantasy_team/store.ex
+++ b/lib/ex338/fantasy_team/store.ex
@@ -19,7 +19,7 @@ defmodule Ex338.FantasyTeam.Store do
   end
 
   def find_all_for_league(league) do
-    league_positions = RosterPosition.Store.positions(league.id)
+    league_positions = RosterPosition.Store.positions(league)
 
     FantasyTeam
     |> FantasyTeam.by_league(league.id)
@@ -63,7 +63,7 @@ defmodule Ex338.FantasyTeam.Store do
       |> FantasyTeam.preload_assocs_by_league(league)
       |> Repo.one()
 
-    league_positions = RosterPosition.Store.positions(team.fantasy_league_id)
+    league_positions = RosterPosition.Store.positions(team.fantasy_league)
 
     team
     |> IRPosition.separate_from_active_for_team()

--- a/lib/ex338/roster_position.ex
+++ b/lib/ex338/roster_position.ex
@@ -7,7 +7,7 @@ defmodule Ex338.RosterPosition do
 
   @default_position ["Unassigned"]
 
-  @flex_positions ["Flex1", "Flex2", "Flex3", "Flex4", "Flex5", "Flex6"]
+  @all_flex_positions ["Flex1", "Flex2", "Flex3", "Flex4", "Flex5", "Flex6"]
 
   @status_options ["active", "injured_reserve", "dropped", "traded", "drafted_pick"]
 
@@ -26,7 +26,9 @@ defmodule Ex338.RosterPosition do
 
   def default_position, do: @default_position
 
-  def flex_positions, do: @flex_positions
+  def all_flex_positions(), do: @all_flex_positions
+
+  def flex_positions(num_positions), do: Enum.map(1..num_positions, &"Flex#{&1}")
 
   def status_options, do: @status_options
 

--- a/lib/ex338/roster_position.ex
+++ b/lib/ex338/roster_position.ex
@@ -11,8 +11,6 @@ defmodule Ex338.RosterPosition do
 
   @status_options ["active", "injured_reserve", "dropped", "traded", "drafted_pick"]
 
-  @max_flex_spots 6
-
   schema "roster_positions" do
     belongs_to(:fantasy_team, Ex338.FantasyTeam)
     field(:position, :string)
@@ -29,8 +27,6 @@ defmodule Ex338.RosterPosition do
   def default_position, do: @default_position
 
   def flex_positions, do: @flex_positions
-
-  def max_flex_spots(), do: @max_flex_spots
 
   def status_options, do: @status_options
 

--- a/lib/ex338/roster_position/store.ex
+++ b/lib/ex338/roster_position/store.ex
@@ -1,31 +1,20 @@
 defmodule Ex338.RosterPosition.Store do
   @moduledoc false
 
-  alias Ex338.{RosterPosition, Repo, SportsLeague}
-
-  def positions_for_draft(fantasy_league_id, championship_id) do
-    RosterPosition
-    |> RosterPosition.all_active()
-    |> RosterPosition.all_draft_picks()
-    |> RosterPosition.from_league(fantasy_league_id)
-    |> RosterPosition.sport_from_champ(championship_id)
-    |> RosterPosition.preload_assocs()
-    |> Repo.all()
-  end
-
-  def positions(fantasy_league_id) do
-    primary_positions = SportsLeague.Store.league_abbrevs(fantasy_league_id)
-    primary_positions ++ RosterPosition.flex_positions()
-  end
-
-  def all_positions(fantasy_league_id) do
-    positions(fantasy_league_id) ++ RosterPosition.default_position()
-  end
+  alias Ex338.{FantasyLeague, RosterPosition, Repo, SportsLeague}
 
   def all_positions() do
     primary_positions = SportsLeague.Store.league_abbrevs()
 
-    primary_positions ++ RosterPosition.flex_positions() ++ RosterPosition.default_position()
+    primary_positions ++ RosterPosition.all_flex_positions() ++ RosterPosition.default_position()
+  end
+
+  def all_positions(fantasy_league) do
+    positions(fantasy_league) ++ RosterPosition.default_position()
+  end
+
+  def get_by(clauses) do
+    Repo.get_by(RosterPosition, clauses)
   end
 
   def list_all() do
@@ -41,7 +30,18 @@ defmodule Ex338.RosterPosition.Store do
     |> Repo.all()
   end
 
-  def get_by(clauses) do
-    Repo.get_by(RosterPosition, clauses)
+  def positions(%FantasyLeague{id: fantasy_league_id, max_flex_spots: max_flex_spots}) do
+    primary_positions = SportsLeague.Store.league_abbrevs(fantasy_league_id)
+    primary_positions ++ RosterPosition.flex_positions(max_flex_spots)
+  end
+
+  def positions_for_draft(fantasy_league_id, championship_id) do
+    RosterPosition
+    |> RosterPosition.all_active()
+    |> RosterPosition.all_draft_picks()
+    |> RosterPosition.from_league(fantasy_league_id)
+    |> RosterPosition.sport_from_champ(championship_id)
+    |> RosterPosition.preload_assocs()
+    |> Repo.all()
   end
 end

--- a/lib/ex338_web/templates/fantasy_team/edit.html.eex
+++ b/lib/ex338_web/templates/fantasy_team/edit.html.eex
@@ -1,6 +1,6 @@
 <h2>Update Fantasy Team</h2>
 
-<%= render "form.html", changeset: @changeset,
+<%= render "form.html", changeset: @changeset, fantasy_team: @fantasy_team,
                         action: fantasy_team_path(@conn, :update, @fantasy_team) %>
 
 <%= link "Back", to: fantasy_team_path(@conn, :show, @fantasy_team.id) %>

--- a/lib/ex338_web/templates/fantasy_team/form.html.eex
+++ b/lib/ex338_web/templates/fantasy_team/form.html.eex
@@ -29,8 +29,9 @@
       <tr>
         <td>
         <div class="form-group">
-        <%= select r, :position, position_selections(r), class: "form-control",
-        prompt: r.data.position %>
+          <%= select r, :position, position_selections(r, @fantasy_team.fantasy_league), 
+              class: "form-control", prompt: r.data.position 
+          %>
           <%= error_tag r, :position %>
         </div>
         </td>

--- a/lib/ex338_web/views/fantasy_team_view.ex
+++ b/lib/ex338_web/views/fantasy_team_view.ex
@@ -1,6 +1,6 @@
 defmodule Ex338Web.FantasyTeamView do
   use Ex338Web, :view
-  alias Ex338.{RosterPosition, DraftQueue}
+  alias Ex338.{FantasyLeague, RosterPosition, DraftQueue}
 
   import Ex338.RosterPosition.RosterAdmin,
     only: [primary_positions: 1, flex_and_unassigned_positions: 1]
@@ -22,9 +22,9 @@ defmodule Ex338Web.FantasyTeamView do
     end
   end
 
-  def position_selections(position_form_struct) do
+  def position_selections(position_form_struct, %FantasyLeague{max_flex_spots: num_spots}) do
     [position_form_struct.data.fantasy_player.sports_league.abbrev] ++
-      RosterPosition.flex_positions()
+      RosterPosition.flex_positions(num_spots)
   end
 
   def queue_status_options() do

--- a/priv/repo/migrations/20180728192433_add_max_flex_to_fantasy_league.exs
+++ b/priv/repo/migrations/20180728192433_add_max_flex_to_fantasy_league.exs
@@ -1,0 +1,9 @@
+defmodule Ex338.Repo.Migrations.AddMaxFlexToFantasyLeague do
+  use Ecto.Migration
+
+  def change do
+    alter table(:fantasy_leagues) do
+      add :max_flex_spots, :integer, default: 6
+    end
+  end
+end

--- a/test/ex338/roster_position/store_test.exs
+++ b/test/ex338/roster_position/store_test.exs
@@ -32,17 +32,18 @@ defmodule Ex338.RosterPosition.StoreTest do
       sport_a = insert(:sports_league, abbrev: "a")
       insert(:sports_league, abbrev: "z")
 
-      league = insert(:fantasy_league)
+      league = insert(:fantasy_league, max_flex_spots: 5)
 
       insert(:league_sport, fantasy_league: league, sports_league: sport_a)
       insert(:league_sport, fantasy_league: league, sports_league: sport_b)
       insert(:league_sport, fantasy_league: league, sports_league: sport_c)
 
-      result = Store.all_positions(league.id)
+      result = Store.all_positions(league)
 
-      assert Enum.count(result) == 10
+      assert Enum.count(result) == 9
       assert Enum.any?(result, &(&1 == sport_a.abbrev))
-      assert Enum.any?(result, &(&1 == "Flex1"))
+      assert Enum.any?(result, &(&1 == "Flex5"))
+      refute Enum.any?(result, &(&1 == "Flex6"))
       assert Enum.any?(result, &(&1 == "Unassigned"))
     end
   end
@@ -126,17 +127,18 @@ defmodule Ex338.RosterPosition.StoreTest do
       sport_a = insert(:sports_league, abbrev: "a")
       insert(:sports_league, abbrev: "z")
 
-      league = insert(:fantasy_league)
+      league = insert(:fantasy_league, max_flex_spots: 5)
 
       insert(:league_sport, fantasy_league: league, sports_league: sport_a)
       insert(:league_sport, fantasy_league: league, sports_league: sport_b)
       insert(:league_sport, fantasy_league: league, sports_league: sport_c)
 
-      result = Store.positions(league.id)
+      result = Store.positions(league)
 
-      assert Enum.count(result) == 9
+      assert Enum.count(result) == 8
       assert Enum.any?(result, &(&1 == sport_a.abbrev))
-      assert Enum.any?(result, &(&1 == "Flex1"))
+      assert Enum.any?(result, &(&1 == "Flex5"))
+      refute Enum.any?(result, &(&1 == "Flex6"))
     end
   end
 

--- a/test/ex338/roster_position_test.exs
+++ b/test/ex338/roster_position_test.exs
@@ -54,4 +54,14 @@ defmodule Ex338.RosterPositionTest do
              ]
     end
   end
+
+  describe "flex_positions/1" do
+    test "changeset with valid attributes" do
+      num_positions = 6
+
+      result = RosterPosition.flex_positions(num_positions)
+
+      assert result == ["Flex1", "Flex2", "Flex3", "Flex4", "Flex5", "Flex6"]
+    end
+  end
 end

--- a/test/ex338_web/views/fantasy_team_view_test.exs
+++ b/test/ex338_web/views/fantasy_team_view_test.exs
@@ -1,6 +1,6 @@
 defmodule Ex338Web.FantasyTeamViewTest do
   use Ex338Web.ConnCase, async: true
-  alias Ex338.{RosterPosition}
+  alias Ex338.{FantasyLeague}
   alias Ex338Web.{FantasyTeamView}
 
   describe "display_points/1" do
@@ -54,9 +54,11 @@ defmodule Ex338Web.FantasyTeamViewTest do
     test "returns sports league abbrev and flex positions" do
       pos_form_struct = %{data: %{fantasy_player: %{sports_league: %{abbrev: "CBB"}}}}
 
-      results = FantasyTeamView.position_selections(pos_form_struct)
+      league = %FantasyLeague{id: 1, max_flex_spots: 2}
 
-      assert results == ["CBB"] ++ RosterPosition.flex_positions()
+      results = FantasyTeamView.position_selections(pos_form_struct, league)
+
+      assert results == ["CBB", "Flex1", "Flex2"]
     end
   end
 

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -76,7 +76,8 @@ defmodule Ex338.Factory do
     %Ex338.FantasyLeague{
       fantasy_league_name: sequence(:division, &"Div#{&1}"),
       division: sequence(:division, &"Div#{&1}"),
-      year: 2017
+      year: 2017,
+      max_flex_spots: 6
     }
   end
 


### PR DESCRIPTION
* Add max_flex_spots to FantasyLeague
* Default set to 6 since all existing leagues are 6
* May change default to 5 in the future due to new rules
* See #437