### PR TITLE
Automate location of rules in header

### DIFF
--- a/lib/ex338_web/templates/layout/header.html.eex
+++ b/lib/ex338_web/templates/layout/header.html.eex
@@ -11,8 +11,6 @@
         <li id="js-navigation-more" class="nav-link more">
           <a href="javascript:void(0)">Leagues</a>
           <ul class="submenu">
-            <li><%= link "2019 Rules", to: "/2019_rules" %></li>
-            <li><%= link "2018 Rules", to: "/2018_rules" %></li>
             <%= render "league_links.html", conn: @conn, leagues: display(@conn.assigns.leagues, :primary) %>
           </ul>
         </li>
@@ -20,7 +18,6 @@
         <li id="js-navigation-more" class="nav-link more">
           <a href="javascript:void(0)">Past Leagues</a>
           <ul class="submenu">
-            <li><%= link "2017 Rules", to: "/2017_rules" %></li>
             <%= render "league_links.html", conn: @conn, leagues: display(@conn.assigns.leagues, :archived) %>
           </ul>
         </li>

--- a/lib/ex338_web/templates/layout/league_links.html.eex
+++ b/lib/ex338_web/templates/layout/league_links.html.eex
@@ -1,5 +1,8 @@
 <%= for league <- @leagues do %>
-  <li class="more"><%= link league.name, to: fantasy_league_path(@conn, :show, league.id) %>
+  <%= if league.division == "A" do %>
+    <li><%= link "#{league.year} Rules", to: "/#{league.year}_rules" %></li>
+  <% end %>
+  <li class="more"><%= link league.fantasy_league_name, to: fantasy_league_path(@conn, :show, league.id) %>
     <ul class="submenu">
       <li><%= link "Standings", to: fantasy_league_path(@conn, :show, league.id) %></li>
       <li><%= link "Teams", to: fantasy_league_fantasy_team_path(@conn, :index, league.id) %></li>

--- a/lib/ex338_web/views/layout_view.ex
+++ b/lib/ex338_web/views/layout_view.ex
@@ -6,7 +6,6 @@ defmodule Ex338Web.LayoutView do
     |> filter_leagues(navbar)
     |> sort_by_div
     |> sort_by_year
-    |> display_name
   end
 
   ## Helpers
@@ -17,17 +16,11 @@ defmodule Ex338Web.LayoutView do
     Enum.filter(fantasy_leagues, &(&1.navbar_display == navbar))
   end
 
-  defp sort_by_year(fantasy_leagues) do
-    Enum.sort_by(fantasy_leagues, & &1.year)
-  end
-
   defp sort_by_div(fantasy_leagues) do
     Enum.sort_by(fantasy_leagues, & &1.division)
   end
 
-  defp display_name(fantasy_leagues) do
-    Enum.map(fantasy_leagues, fn league ->
-      %{id: league.id, name: "#{league.year} Div #{league.division}"}
-    end)
+  defp sort_by_year(fantasy_leagues) do
+    Enum.sort_by(fantasy_leagues, & &1.year)
   end
 end

--- a/priv/repo/csv_seed_data/fantasy_leagues.csv
+++ b/priv/repo/csv_seed_data/fantasy_leagues.csv
@@ -2,4 +2,4 @@ Fantasy League Name, Year, Division
 2017 Div A,2017,A
 2017 Div B,2017,B
 2018 Div A,2018,A
-2018 Div B,2017,B
+2018 Div B,2018,B

--- a/test/ex338_web/views/layout_view_test.exs
+++ b/test/ex338_web/views/layout_view_test.exs
@@ -5,30 +5,49 @@ defmodule Ex338Web.LayoutViewTest do
   alias Ex338.{FantasyLeague}
 
   @leagues [
-    %FantasyLeague{id: 5, navbar_display: :hidden, division: "NA", year: 2019},
-    %FantasyLeague{id: 4, navbar_display: :primary, division: "A", year: 2019},
-    %FantasyLeague{id: 3, navbar_display: :primary, division: "A", year: 2018},
-    %FantasyLeague{id: 2, navbar_display: :primary, division: "B", year: 2018},
-    %FantasyLeague{id: 1, navbar_display: :archived, division: "A", year: 2017}
+    %FantasyLeague{
+      id: 5,
+      navbar_display: :hidden,
+      division: "NA",
+      year: 2019
+    },
+    %FantasyLeague{
+      id: 4,
+      navbar_display: :primary,
+      division: "A",
+      year: 2019
+    },
+    %FantasyLeague{
+      id: 3,
+      navbar_display: :primary,
+      division: "A",
+      year: 2018
+    },
+    %FantasyLeague{
+      id: 2,
+      navbar_display: :primary,
+      division: "B",
+      year: 2018
+    },
+    %FantasyLeague{
+      id: 1,
+      navbar_display: :archived,
+      division: "A",
+      year: 2017
+    }
   ]
 
   describe "display/2" do
     test "returns primary leagues for navbar display" do
       result = LayoutView.display(@leagues, :primary)
 
-      assert result == [
-               %{id: 3, name: "2018 Div A"},
-               %{id: 2, name: "2018 Div B"},
-               %{id: 4, name: "2019 Div A"}
-             ]
+      assert Enum.map(result, & &1.id) == [3, 2, 4]
     end
 
     test "returns archived leagues for navbar display" do
-      result = LayoutView.display(@leagues, :archived)
+      [result] = LayoutView.display(@leagues, :archived)
 
-      assert result == [
-               %{id: 1, name: "2017 Div A"}
-             ]
+      assert result.id == 1
     end
   end
 end


### PR DESCRIPTION
* Automate location of rules in header based on Div A
* Puts rules directly above the Div A for each year
* Fixes typo in FantasyLeague seed data
* Closes #484