### PR TITLE
Sort leagues in header by earliest year first

### DIFF
--- a/lib/ex338_web/views/layout_view.ex
+++ b/lib/ex338_web/views/layout_view.ex
@@ -21,6 +21,6 @@ defmodule Ex338Web.LayoutView do
   end
 
   defp sort_by_year(fantasy_leagues) do
-    Enum.sort_by(fantasy_leagues, & &1.year)
+    Enum.sort_by(fantasy_leagues, & &1.year, &>=/2)
   end
 end

--- a/test/ex338_web/views/layout_view_test.exs
+++ b/test/ex338_web/views/layout_view_test.exs
@@ -41,7 +41,7 @@ defmodule Ex338Web.LayoutViewTest do
     test "returns primary leagues for navbar display" do
       result = LayoutView.display(@leagues, :primary)
 
-      assert Enum.map(result, & &1.id) == [3, 2, 4]
+      assert Enum.map(result, & &1.id) == [4, 3, 2]
     end
 
     test "returns archived leagues for navbar display" do


### PR DESCRIPTION
* Sort leagues in header by earliest year first
* Earliest first seems more intuitive
* Closes #487