### PR TITLE
Add all links to breadcrumbs

### DIFF
--- a/lib/ex338_web/templates/shared/nav_breadcrumbs.html.eex
+++ b/lib/ex338_web/templates/shared/nav_breadcrumbs.html.eex
@@ -4,6 +4,8 @@
   <%= link "Players", to: fantasy_league_fantasy_player_path(@conn, :index, @fantasy_league.id) %>
   <%= link "Championships", to: fantasy_league_championship_path(@conn, :index, @fantasy_league.id) %>
   <%= link "Waivers", to: fantasy_league_waiver_path(@conn, :index, @fantasy_league.id) %>
+  <%= link "IR", to: fantasy_league_injured_reserve_path(@conn, :index, @fantasy_league.id) %>
   <%= link "Draft", to: fantasy_league_draft_pick_path(@conn, :index, @fantasy_league.id) %>
+  <%= link "Trades", to: fantasy_league_trade_path(@conn, :index, @fantasy_league.id) %>
+  <%= link "Owners", to: fantasy_league_owner_path(@conn, :index, @fantasy_league.id) %>
 </div>
-


### PR DESCRIPTION
* Add IR, Trade, and Owner links to breadcrumbs
* I had left them off to keep the breadcrumbs on 1 line for mobile
* It is already on the second line so might as well add them
* Future update is to scroll on mobile or use flex
* See #522