### PR TITLE
Change display of 0 points for fantasy teams

### DIFF
--- a/assets/css/_fantasy_teams.scss
+++ b/assets/css/_fantasy_teams.scss
@@ -43,6 +43,16 @@
       th:nth-child(4) {
         text-align: right;
       }
+
+      th.points,
+      td.points {
+        text-align: right;
+      }
+
+      th.rank,
+      td.rank {
+        text-align: left;
+      }
     }
 
     .draft-queue-table {
@@ -55,17 +65,9 @@
   }
 }
 
-.fantasy-team-table {
 
-  th.points,
-  td.points {
-    text-align: right;
-  }
-
-  th.rank,
-  td.rank {
-    text-align: left;
-  }
+td.points-0 {
+  color: $medium-gray;
 }
 
 .dues {

--- a/lib/ex338_web/templates/fantasy_team/table_row.html.eex
+++ b/lib/ex338_web/templates/fantasy_team/table_row.html.eex
@@ -1,14 +1,12 @@
 <tr>
   <td><%= @roster_position.position %></td>
   <td>
-    <%= if @roster_position.fantasy_player, 
-      do: @roster_position.fantasy_player.player_name %>
+    <%= if @roster_position.fantasy_player, do: @roster_position.fantasy_player.player_name %>
   </td>
   <td>
-    <%= if @roster_position.fantasy_player,
-      do: @roster_position.fantasy_player.sports_league.abbrev %>
+    <%= if @roster_position.fantasy_player, do: @roster_position.fantasy_player.sports_league.abbrev %>
   </td>
-  <td><%= if @roster_position.fantasy_player do %>
-        <%= display_points(@roster_position) %>
-      <% end %>
+  <td class="points-<%= display_points(@roster_position) %>">
+    <%= display_points(@roster_position) %>
+  </td>
 </tr>

--- a/lib/ex338_web/views/fantasy_team_view.ex
+++ b/lib/ex338_web/views/fantasy_team_view.ex
@@ -48,6 +48,6 @@ defmodule Ex338Web.FantasyTeamView do
   ## display_points
 
   defp display_value(nil, false), do: ""
-  defp display_value(nil, true), do: "-"
+  defp display_value(nil, true), do: 0
   defp display_value(result, _), do: Map.get(result, :points)
 end

--- a/test/ex338_web/views/fantasy_team_view_test.exs
+++ b/test/ex338_web/views/fantasy_team_view_test.exs
@@ -39,7 +39,13 @@ defmodule Ex338Web.FantasyTeamViewTest do
     test "returns a dash if no points and season has ended" do
       position = %{season_ended?: true, fantasy_player: %{championship_results: []}}
 
-      assert FantasyTeamView.display_points(position) == "-"
+      assert FantasyTeamView.display_points(position) == 0
+    end
+
+    test "returns empty string if no fantasy player exists" do
+      position = %{}
+
+      assert FantasyTeamView.display_points(position) == ""
     end
   end
 


### PR DESCRIPTION
* Change from - to a light gray 0 when a player scores 0 points
* More explicit about 0 points scored
* Light gray still highlights when points are actually scored
* See #535