### PR TITLE
Fix ir_positions bug in FantasyTeam.Store module

### DIFF
--- a/lib/ex338/fantasy_team/store.ex
+++ b/lib/ex338/fantasy_team/store.ex
@@ -24,9 +24,9 @@ defmodule Ex338.FantasyTeam.Store do
     |> FantasyTeam.preload_assocs_by_league(league)
     |> FantasyTeam.alphabetical()
     |> Repo.all()
+    |> Deadlines.add_for_league()
     |> RosterPosition.IRPosition.separate_from_active_for_teams()
     |> RosterPosition.OpenPosition.add_open_positions_to_teams(league_positions)
-    |> Deadlines.add_for_league()
     |> Standings.rank_points_winnings_for_teams()
     |> FantasyTeam.sort_alphabetical()
     |> load_slot_results
@@ -73,10 +73,10 @@ defmodule Ex338.FantasyTeam.Store do
     league_positions = RosterPosition.Store.positions(team.fantasy_league)
 
     team
+    |> Deadlines.add_for_team()
     |> RosterPosition.IRPosition.separate_from_active_for_team()
     |> RosterPosition.OpenPosition.add_open_positions_to_team(league_positions)
     |> Standings.update_points_winnings()
-    |> Deadlines.add_for_team()
     |> FantasyTeam.sort_queues_by_order()
     |> load_slot_results
   end

--- a/test/ex338_web/controllers/fantasy_team_controller_test.exs
+++ b/test/ex338_web/controllers/fantasy_team_controller_test.exs
@@ -11,7 +11,21 @@ defmodule Ex338Web.FantasyTeamControllerTest do
   describe "index/2" do
     test "lists all fantasy teams in a fantasy league", %{conn: conn} do
       league = insert(:fantasy_league)
-      insert_list(2, :fantasy_team, fantasy_league: league)
+      teams = insert_list(2, :fantasy_team, fantasy_league: league)
+
+      sport = insert(:sports_league)
+      insert(:championship, sports_league: sport)
+      insert(:league_sport, fantasy_league: league, sports_league: sport)
+      insert(:fantasy_player, sports_league: sport)
+
+      ir_player = insert(:fantasy_player, sports_league: sport)
+
+      insert(
+        :roster_position,
+        fantasy_team: hd(teams),
+        fantasy_player: ir_player,
+        status: "injured_reserve"
+      )
 
       conn = get(conn, fantasy_league_fantasy_team_path(conn, :index, league.id))
 
@@ -109,12 +123,13 @@ defmodule Ex338Web.FantasyTeamControllerTest do
       insert(:owner, user: conn.assigns.current_user, fantasy_team: team)
 
       sport = insert(:sports_league)
+      insert(:championship, sports_league: sport)
       insert(:league_sport, fantasy_league: league, sports_league: sport)
       insert(:fantasy_player, sports_league: sport)
 
-      unassigned_player = insert(:fantasy_player)
-      dropped_player = insert(:fantasy_player)
-      ir_player = insert(:fantasy_player)
+      unassigned_player = insert(:fantasy_player, sports_league: sport)
+      dropped_player = insert(:fantasy_player, sports_league: sport)
+      ir_player = insert(:fantasy_player, sports_league: sport)
 
       insert(
         :roster_position,


### PR DESCRIPTION
* Fix IR-related bug in FantasyTeam.Store module
* Deadlines.add_for_league/1 missed ir_positions
* Applied after ir_positions separated from roster_positions
* Moved above IRPosition.separate_from_active_for_teams/1 to fix
* Closes #553