### PR TITLE
Add `inspect` to print mailer error

### DIFF
--- a/lib/ex338_web/mailer.ex
+++ b/lib/ex338_web/mailer.ex
@@ -10,7 +10,7 @@ defmodule Ex338Web.Mailer do
   end
 
   def handle_delivery({:error, {_, reason}}) do
-    Logger.error("Email failed to send: #{reason}")
+    Logger.error("Email failed to send: #{inspect(reason)}")
     {:error, reason}
   end
 end

--- a/test/ex338_web/mailer_test.exs
+++ b/test/ex338_web/mailer_test.exs
@@ -9,7 +9,7 @@ defmodule Ex338Web.MailerTest do
   describe "handle_delivery/1" do
     test "logs an error email" do
       delivery = {:error, {:error, "reason"}}
-      expected_msg = "Email failed to send: reason"
+      expected_msg = "reason"
 
       assert capture_log(fn ->
                Mailer.handle_delivery(delivery)


### PR DESCRIPTION
* Current approach throws and error in staging when no SendGrid API
* Closes #600