### PR TITLE
Fix bug in Championship index

### DIFF
--- a/lib/ex338/championship.ex
+++ b/lib/ex338/championship.ex
@@ -119,12 +119,6 @@ defmodule Ex338.Championship do
     from(c in query, where: c.category == "overall")
   end
 
-  def preload_assocs(query) do
-    results = ChampionshipResult.preload_assocs_and_order_results(ChampionshipResult)
-
-    from(c in query, preload: [:sports_league, championship_results: ^results])
-  end
-
   def preload_assocs_by_league(query, league_id) do
     champ_with_event_results =
       ChampWithEventsResult.preload_ordered_assocs_by_league(ChampWithEventsResult, league_id)

--- a/lib/ex338/championship/store.ex
+++ b/lib/ex338/championship/store.ex
@@ -6,20 +6,20 @@ defmodule Ex338.Championship.Store do
   def all_for_league(fantasy_league_id) do
     Championship
     |> Championship.all_for_league(fantasy_league_id)
-    |> Championship.preload_assocs()
+    |> Championship.preload_assocs_by_league(fantasy_league_id)
     |> Championship.earliest_first()
     |> Repo.all()
     |> Enum.map(&Championship.add_deadline_statuses/1)
   end
 
-  def get_championship_by_league(id, league_id) do
+  def get_championship_by_league(id, fantasy_league_id) do
     Championship
-    |> Championship.preload_assocs_by_league(league_id)
+    |> Championship.preload_assocs_by_league(fantasy_league_id)
     |> Repo.get!(id)
     |> Championship.add_deadline_statuses()
     |> update_next_in_season_pick
-    |> preload_events_by_league(league_id)
-    |> get_slot_standings(league_id)
+    |> preload_events_by_league(fantasy_league_id)
+    |> get_slot_standings(fantasy_league_id)
   end
 
   def preload_events_by_league(championship, league_id) do

--- a/lib/ex338/championship_result.ex
+++ b/lib/ex338/championship_result.ex
@@ -63,16 +63,6 @@ defmodule Ex338.ChampionshipResult do
     |> before_date_in_year(datetime)
   end
 
-  def preload_assocs(query) do
-    from(c in query, preload: [:fantasy_player])
-  end
-
-  def preload_assocs_and_order_results(query) do
-    query
-    |> preload_assocs
-    |> order_by_points_rank
-  end
-
   def preload_assocs_by_league(query, league_id) do
     from(
       cr in query,

--- a/test/ex338/championship_repo_test.exs
+++ b/test/ex338/championship_repo_test.exs
@@ -242,29 +242,6 @@ defmodule Ex338.ChampionshipRepoTest do
     end
   end
 
-  describe "preload_assocs/1" do
-    test "returns any associated sports leagues" do
-      league = insert(:sports_league)
-      championship = insert(:championship, sports_league: league)
-      player = insert(:fantasy_player, sports_league: league)
-
-      champ_result =
-        insert(
-          :championship_result,
-          championship: championship,
-          fantasy_player: player
-        )
-
-      result =
-        Championship
-        |> Championship.preload_assocs()
-        |> Repo.one()
-
-      assert result.sports_league.id == league.id
-      assert Enum.at(result.championship_results, 0).id == champ_result.id
-    end
-  end
-
   describe "preload_assocs_by_league/2" do
     test "preloads all assocs for a league" do
       f_league_a = insert(:fantasy_league)

--- a/test/ex338/championship_result_test.exs
+++ b/test/ex338/championship_result_test.exs
@@ -138,37 +138,6 @@ defmodule Ex338.ChampionshipResultTest do
     end
   end
 
-  describe "preload_assocs/1" do
-    test "returns any associated fantasy players" do
-      player = insert(:fantasy_player)
-      insert(:championship_result, fantasy_player: player)
-
-      result =
-        ChampionshipResult
-        |> ChampionshipResult.preload_assocs()
-        |> Repo.one()
-
-      assert result.fantasy_player.id == player.id
-    end
-  end
-
-  describe "preload_assocs_and_order_results/1" do
-    test "returns championship results in order by points then rank with assocs" do
-      insert(:championship_result, points: 8, rank: 1)
-      insert(:championship_result, points: 5, rank: 2)
-      insert(:championship_result, points: 3, rank: 4)
-      insert(:championship_result, points: 3, rank: 3)
-      insert(:championship_result, points: -1, rank: 0)
-
-      result =
-        ChampionshipResult
-        |> ChampionshipResult.preload_assocs_and_order_results()
-        |> Repo.all()
-
-      assert Enum.map(result, & &1.rank) == [1, 2, 3, 4, 0]
-    end
-  end
-
   describe "preload_assocs_by_league/2" do
     test "preloads all assocs for a league" do
       player_a = insert(:fantasy_player)


### PR DESCRIPTION
* Fix bug in Championship index
* Owner not shown if no longer on the roster
* Should still show if on roster during championship
* Need to use `preload_assocs_by_league/2`
* `preload_assocs/1` not used anywhere else
* Closes #613