### PR TITLE
Update autodraft to handle skipped teams

### DIFF
--- a/lib/ex338/draft_pick.ex
+++ b/lib/ex338/draft_pick.ex
@@ -25,7 +25,7 @@ defmodule Ex338.DraftPick do
 
       index_next_team_under_limit ->
         remaining_picks
-        |> get_available_pick_ids(index_next_team_under_limit)
+        |> get_available_picks(index_next_team_under_limit)
         |> draft_pick_available?(draft_pick_id)
     end
   end
@@ -47,6 +47,18 @@ defmodule Ex338.DraftPick do
       :fantasy_player_id
     ])
     |> validate_required([:draft_position, :fantasy_league_id])
+  end
+
+  def picks_available_with_skips(draft_picks) do
+    remaining_picks = remove_completed_picks(draft_picks)
+
+    case find_index_of_next_team_under_limit(remaining_picks) do
+      nil ->
+        nil
+
+      index_next_team_under_limit ->
+        get_available_picks(remaining_picks, index_next_team_under_limit)
+    end
   end
 
   def last_picks(query, league_id, picks) do
@@ -111,15 +123,16 @@ defmodule Ex338.DraftPick do
     )
   end
 
-  defp get_available_pick_ids(remaining_picks, index_next_team_under_limit) do
+  defp get_available_picks(remaining_picks, index_next_team_under_limit) do
     remaining_picks
     |> Enum.take(index_next_team_under_limit + 1)
     |> Enum.reject(&(&1.fantasy_player_id !== nil))
-    |> Enum.map(& &1.id)
   end
 
-  defp draft_pick_available?(available_pick_ids, draft_pick_id) do
-    Enum.any?(available_pick_ids, &(&1 == draft_pick_id))
+  defp draft_pick_available?(available_picks, draft_pick_id) do
+    available_picks
+    |> Enum.map(& &1.id)
+    |> Enum.any?(&(&1 == draft_pick_id))
   end
 
   ## owner_changeset

--- a/lib/ex338/draft_pick/store.ex
+++ b/lib/ex338/draft_pick/store.ex
@@ -24,6 +24,12 @@ defmodule Ex338.DraftPick.Store do
     |> Repo.all()
   end
 
+  def get_picks_available_with_skips(fantasy_league_id) do
+    %{draft_picks: draft_picks} = get_picks_for_league(fantasy_league_id)
+
+    DraftPick.picks_available_with_skips(draft_picks)
+  end
+
   def get_picks_for_league(fantasy_league_id) do
     draft_picks =
       DraftPick

--- a/test/ex338/draft_pick/store_test.exs
+++ b/test/ex338/draft_pick/store_test.exs
@@ -171,6 +171,63 @@ defmodule Ex338.DraftPick.StoreTest do
     end
   end
 
+  describe "get_picks_available_with_skips/1" do
+    test "returns available picks to make with skips" do
+      league = insert(:fantasy_league, max_draft_hours: 1)
+      team_a = insert(:fantasy_team, fantasy_league: league)
+      team_b = insert(:fantasy_team, fantasy_league: league)
+      team_c = insert(:fantasy_team, fantasy_league: league)
+      team_d = insert(:fantasy_team, fantasy_league: league)
+
+      player_a = insert(:fantasy_player)
+      player_b = insert(:fantasy_player)
+      player_c = insert(:fantasy_player)
+
+      _completed_pick =
+        insert(:draft_pick,
+          draft_position: 1,
+          fantasy_team: team_a,
+          fantasy_player: player_a,
+          fantasy_league: league,
+          drafted_at: DateTime.from_naive!(~N[2018-09-21 01:10:02.857392], "Etc/UTC")
+        )
+
+      _over_limit_pick =
+        insert(:draft_pick,
+          draft_position: 2,
+          fantasy_team: team_b,
+          fantasy_player: player_b,
+          fantasy_league: league,
+          drafted_at: DateTime.from_naive!(~N[2018-09-21 03:10:02.857392], "Etc/UTC")
+        )
+
+      _over_limit_pick2 =
+        insert(:draft_pick,
+          draft_position: 3,
+          fantasy_team: team_c,
+          fantasy_player: player_c,
+          fantasy_league: league,
+          drafted_at: DateTime.from_naive!(~N[2018-09-21 05:10:02.857392], "Etc/UTC")
+        )
+
+      skipped_pick =
+        insert(:draft_pick, draft_position: 4, fantasy_team: team_b, fantasy_league: league)
+
+      skipped_pick2 =
+        insert(:draft_pick, draft_position: 5, fantasy_team: team_c, fantasy_league: league)
+
+      next_pick =
+        insert(:draft_pick, draft_position: 6, fantasy_team: team_d, fantasy_league: league)
+
+      _not_available =
+        insert(:draft_pick, draft_position: 7, fantasy_team: team_a, fantasy_league: league)
+
+      results = Store.get_picks_available_with_skips(league.id)
+
+      assert Enum.map(results, & &1.id) == [skipped_pick.id, skipped_pick2.id, next_pick.id]
+    end
+  end
+
   describe "get_picks_for_league/1" do
     test "returns draft picks in descending order" do
       league = insert(:fantasy_league)

--- a/test/ex338/draft_pick_test.exs
+++ b/test/ex338/draft_pick_test.exs
@@ -73,6 +73,56 @@ defmodule Ex338.DraftPickTest do
     end
   end
 
+  describe "picks_available_with_skips/1" do
+    test "returns available picks to make with skips" do
+      team_a = %{over_draft_time_limit?: false}
+      team_b = %{over_draft_time_limit?: true}
+      team_c = %{over_draft_time_limit?: true}
+      team_d = %{over_draft_time_limit?: false}
+
+      completed_pick = %{id: 1, draft_position: 1, fantasy_player_id: 1, fantasy_team: team_a}
+      skipped_pick = %{id: 2, draft_position: 2, fantasy_player_id: nil, fantasy_team: team_b}
+      skipped_pick2 = %{id: 3, draft_position: 3, fantasy_player_id: nil, fantasy_team: team_c}
+      next_pick = %{id: 4, draft_position: 4, fantasy_player_id: nil, fantasy_team: team_d}
+      not_available = %{id: 5, draft_position: 5, fantasy_player_id: nil, fantasy_team: team_a}
+
+      draft_picks = [completed_pick, skipped_pick, skipped_pick2, next_pick, not_available]
+
+      results = DraftPick.picks_available_with_skips(draft_picks)
+
+      assert Enum.map(results, & &1.id) == [skipped_pick.id, skipped_pick2.id, next_pick.id]
+    end
+
+    test "returns nil when no pick is available to make" do
+      team_a = %{over_draft_time_limit?: false}
+
+      completed_pick = %{id: 1, draft_position: 1, fantasy_player_id: 1, fantasy_team: team_a}
+
+      draft_picks = [completed_pick]
+
+      assert DraftPick.picks_available_with_skips(draft_picks) == nil
+    end
+
+    test "returns available picks when skip pick is made" do
+      team_a = %{over_draft_time_limit?: false}
+      team_b = %{over_draft_time_limit?: true}
+      team_c = %{over_draft_time_limit?: true}
+      team_d = %{over_draft_time_limit?: false}
+
+      completed_pick = %{id: 1, draft_position: 1, fantasy_player_id: 1, fantasy_team: team_a}
+      skipped_pick = %{id: 2, draft_position: 2, fantasy_player_id: nil, fantasy_team: team_b}
+      completed_pick2 = %{id: 1, draft_position: 1, fantasy_player_id: 1, fantasy_team: team_c}
+      next_pick = %{id: 4, draft_position: 4, fantasy_player_id: nil, fantasy_team: team_d}
+      not_available = %{id: 5, draft_position: 5, fantasy_player_id: nil, fantasy_team: team_a}
+
+      draft_picks = [completed_pick, skipped_pick, completed_pick2, next_pick, not_available]
+
+      results = DraftPick.picks_available_with_skips(draft_picks)
+
+      assert Enum.map(results, & &1.id) == [skipped_pick.id, next_pick.id]
+    end
+  end
+
   @valid_attrs %{draft_position: "1.05", round: 42, fantasy_league_id: 1}
   @valid_user_attrs %{
     draft_position: "1.05",


### PR DESCRIPTION
* Refactor DraftPick to expose picks_available_with_skips/1
* Add DraftPick.Store.get_picks_available_with_skips/1
* Handle skipped teams when autodrafting
* Closes #627