### PR TITLE
Champs start

### DIFF
--- a/lib/ex338/championship.ex
+++ b/lib/ex338/championship.ex
@@ -93,7 +93,8 @@ defmodule Ex338.Championship do
       join: ls in assoc(s, :league_sports),
       join: f in assoc(ls, :fantasy_league),
       where: f.id == ^fantasy_league_id,
-      where: f.year == c.year
+      where: c.championship_at >= f.championships_start_at,
+      where: c.championship_at <= f.championships_end_at
     )
   end
 

--- a/lib/ex338/fantasy_league.ex
+++ b/lib/ex338/fantasy_league.ex
@@ -7,6 +7,8 @@ defmodule Ex338.FantasyLeague do
     field(:fantasy_league_name, :string)
     field(:year, :integer)
     field(:division, :string)
+    field(:championships_start_at, :utc_datetime)
+    field(:championships_end_at, :utc_datetime)
     field(:navbar_display, FantasyLeagueNavbarDisplayEnum, default: "primary")
     field(:draft_method, FantasyLeagueDraftMethodEnum, default: "redraft")
     field(:max_draft_hours, :integer, default: 0)
@@ -29,6 +31,8 @@ defmodule Ex338.FantasyLeague do
   def changeset(struct, params \\ %{}) do
     struct
     |> cast(params, [
+      :championships_end_at,
+      :championships_start_at,
       :division,
       :draft_method,
       :fantasy_league_name,

--- a/priv/repo/csv_seed_data/fantasy_leagues.csv
+++ b/priv/repo/csv_seed_data/fantasy_leagues.csv
@@ -1,5 +1,5 @@
-Fantasy League Name, Year, Division
-2017 Div A,2017,A
-2017 Div B,2017,B
-2018 Div A,2018,A
-2018 Div B,2018,B
+Fantasy League Name, Year, Division,Championship Starts At,Championship Ends At
+2017 Div A,2017,A,-94,271
+2017 Div B,2017,B,-94,271
+2018 Div A,2018,A,255,620
+2018 Div B,2018,B,255,620

--- a/priv/repo/dev_seeds.exs
+++ b/priv/repo/dev_seeds.exs
@@ -33,8 +33,28 @@ defmodule Ex338.DevSeeds do
   }
 
   def store_fantasy_leagues(row) do
+    row = convert_fantasy_league_dates(row)
     changeset = FantasyLeague.changeset(%FantasyLeague{}, row)
     Repo.insert!(changeset)
+  end
+
+  defp convert_fantasy_league_dates(
+         %{
+           championships_start_at: start_at_days,
+           championships_end_at: end_at_days
+         } = fantasy_league
+       ) do
+    %{
+      fantasy_league
+      | championships_start_at: to_date(start_at_days),
+        championships_end_at: to_date(end_at_days)
+    }
+  end
+
+  defp to_date(days) do
+    days
+    |> String.to_integer()
+    |> CalendarAssistant.days_from_now()
   end
 
   def store_league_sports(row) do
@@ -111,7 +131,15 @@ end
 
 File.stream!("priv/repo/csv_seed_data/fantasy_leagues.csv")
 |> Stream.drop(1)
-|> CSV.decode!(headers: [:fantasy_league_name, :year, :division])
+|> CSV.decode!(
+  headers: [
+    :fantasy_league_name,
+    :year,
+    :division,
+    :championships_start_at,
+    :championships_end_at
+  ]
+)
 |> Enum.each(&Ex338.DevSeeds.store_fantasy_leagues/1)
 
 File.stream!("priv/repo/csv_seed_data/league_sports.csv")

--- a/priv/repo/migrations/20190803213203_add_championship_date_range_to_fantasy_league.exs
+++ b/priv/repo/migrations/20190803213203_add_championship_date_range_to_fantasy_league.exs
@@ -1,0 +1,10 @@
+defmodule Ex338.Repo.Migrations.AddChampionshipDateRangeToFantasyLeague do
+  use Ecto.Migration
+
+  def change do
+    alter table(:fantasy_leagues) do
+      add(:championships_start_at, :utc_datetime)
+      add(:championships_end_at, :utc_datetime)
+    end
+  end
+end

--- a/test/ex338/fantasy_player_repo_test.exs
+++ b/test/ex338/fantasy_player_repo_test.exs
@@ -67,8 +67,8 @@ defmodule Ex338.FantasyPlayerRepoTest do
       insert(
         :championship,
         sports_league: league_b,
-        year: 2018,
-        waiver_deadline_at: CalendarAssistant.days_from_now(360)
+        waiver_deadline_at: CalendarAssistant.days_from_now(360),
+        championship_at: CalendarAssistant.days_from_now(365)
       )
 
       player_a = insert(:fantasy_player, sports_league: league_a, player_name: "A")
@@ -392,28 +392,25 @@ defmodule Ex338.FantasyPlayerRepoTest do
       insert(
         :championship,
         sports_league: sport_open,
-        year: 2017,
         waiver_deadline_at: CalendarAssistant.days_from_now(5)
       )
 
       insert(
         :championship,
         sports_league: sport_closed,
-        year: 2017,
         waiver_deadline_at: CalendarAssistant.days_from_now(-5)
       )
 
       insert(
         :championship,
         sports_league: sport_next_year,
-        year: 2018,
-        waiver_deadline_at: CalendarAssistant.days_from_now(360)
+        waiver_deadline_at: CalendarAssistant.days_from_now(360),
+        championship_at: CalendarAssistant.days_from_now(365)
       )
 
       insert(
         :championship,
         sports_league: sport_not_in_league,
-        year: 2017,
         waiver_deadline_at: CalendarAssistant.days_from_now(5)
       )
 

--- a/test/ex338/sports_league_repo_test.exs
+++ b/test/ex338/sports_league_repo_test.exs
@@ -1,6 +1,6 @@
 defmodule Ex338.SportsLeagueRepoTest do
   use Ex338.DataCase
-  alias Ex338.SportsLeague
+  alias Ex338.{CalendarAssistant, SportsLeague}
 
   describe "abbrev_a_to_z/1" do
     test "sorts abbrev a to z" do
@@ -59,13 +59,35 @@ defmodule Ex338.SportsLeagueRepoTest do
 
   describe "preload_league_overall_championships/2" do
     test "return overall championships for a fantasy league" do
-      league_a = insert(:fantasy_league, year: 2018)
+      league_a =
+        insert(:fantasy_league,
+          championships_start_at: CalendarAssistant.days_from_now(-180),
+          championships_end_at: CalendarAssistant.days_from_now(180)
+        )
+
       sport_a = insert(:sports_league)
       insert(:league_sport, fantasy_league: league_a, sports_league: sport_a)
 
-      champ = insert(:championship, sports_league: sport_a, category: "overall", year: 2018)
-      insert(:championship, sports_league: sport_a, category: "event", year: 2018)
-      insert(:championship, sports_league: sport_a, category: "overall", year: 2017)
+      champ =
+        insert(:championship,
+          sports_league: sport_a,
+          category: "overall",
+          championship_at: CalendarAssistant.days_from_now(20)
+        )
+
+      _event =
+        insert(:championship,
+          sports_league: sport_a,
+          category: "event",
+          championship_at: CalendarAssistant.days_from_now(20)
+        )
+
+      _prev_year =
+        insert(:championship,
+          sports_league: sport_a,
+          category: "overall",
+          championship_at: CalendarAssistant.days_from_now(-365)
+        )
 
       %{championships: [result]} =
         SportsLeague

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -77,6 +77,8 @@ defmodule Ex338.Factory do
       fantasy_league_name: sequence(:division, &"Div#{&1}"),
       division: sequence(:division, &"Div#{&1}"),
       year: 2017,
+      championships_start_at: CalendarAssistant.days_from_now(-180),
+      championships_end_at: CalendarAssistant.days_from_now(180),
       max_draft_hours: 0,
       max_flex_spots: 6,
       draft_method: "redraft"


### PR DESCRIPTION
* Add championship date range to FantasyLeague
* Used to replace years when querying championships
* Keeper league crosses calendar years, so query is broken
* Update championship query & tests
* Update factory default for fantasy league range with days from now to match default championship days from now
* Update other tests for championship range vs year
* Update seeds for championship range in FantasyLeague
* Closes #648