### PR TITLE
Update players to use date range for availability

### DIFF
--- a/priv/repo/migrations/20190908210456_add_start_end_dates_to_fantasy_player.exs
+++ b/priv/repo/migrations/20190908210456_add_start_end_dates_to_fantasy_player.exs
@@ -1,0 +1,10 @@
+defmodule Ex338.Repo.Migrations.AddStartEndDatesToFantasyPlayer do
+  use Ecto.Migration
+
+  def change do
+    alter table(:fantasy_players) do
+      add(:available_starting_at, :utc_datetime)
+      add(:archived_at, :utc_datetime)
+    end
+  end
+end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -90,6 +90,7 @@ defmodule Ex338.Factory do
       player_name: sequence(:player_name, &"Player ##{&1}"),
       draft_pick: false,
       start_year: 2017,
+      available_starting_at: CalendarAssistant.days_from_now(-365),
       sports_league: build(:sports_league)
     }
   end


### PR DESCRIPTION
* Update players to use date range for availability
* Original approach used start_year/end_year
* Keeper league crosses years, so LLWS is an issue
* Add available_starting_at & archived_at columns
* Update FantasyPlayer.active_players/2 query
* See #664