### PR TITLE
Allow DraftQueue cancellation without validation

### DIFF
--- a/lib/ex338/draft_pick.ex
+++ b/lib/ex338/draft_pick.ex
@@ -108,6 +108,11 @@ defmodule Ex338.DraftPick do
     from(d in query, order_by: [desc: d.draft_position])
   end
 
+  def validate_max_flex_spots(%{changes: %{status: status}} = draft_pick_changeset)
+      when status in [:cancelled, :unavailable] do
+    draft_pick_changeset
+  end
+
   def validate_max_flex_spots(draft_pick_changeset) do
     team_id = get_field(draft_pick_changeset, :fantasy_team_id)
     drafted_player_id = get_field(draft_pick_changeset, :fantasy_player_id)

--- a/test/ex338/draft_queue_test.exs
+++ b/test/ex338/draft_queue_test.exs
@@ -178,6 +178,58 @@ defmodule Ex338.DraftQueueTest do
              ]
     end
 
+    test "no error if unavailable when too many flex spots in use" do
+      league = insert(:fantasy_league, max_flex_spots: 5)
+      team = insert(:fantasy_team, fantasy_league: league)
+      regular_positions = insert_list(4, :roster_position, fantasy_team: team)
+
+      flex_sport = List.first(regular_positions).fantasy_player.sports_league
+
+      [add | plyrs] = insert_list(7, :fantasy_player, sports_league: flex_sport)
+
+      _flex_slots =
+        for plyr <- plyrs do
+          insert(:roster_position, fantasy_team: team, fantasy_player: plyr)
+        end
+
+      attrs = %{
+        fantasy_team_id: team.id,
+        fantasy_player_id: add.id,
+        order: 1,
+        status: "unavailable"
+      }
+
+      changeset = DraftQueue.changeset(%DraftQueue{}, attrs)
+
+      assert changeset.valid?
+    end
+
+    test "no error if cancelled when too many flex spots in use" do
+      league = insert(:fantasy_league, max_flex_spots: 5)
+      team = insert(:fantasy_team, fantasy_league: league)
+      regular_positions = insert_list(4, :roster_position, fantasy_team: team)
+
+      flex_sport = List.first(regular_positions).fantasy_player.sports_league
+
+      [add | plyrs] = insert_list(7, :fantasy_player, sports_league: flex_sport)
+
+      _flex_slots =
+        for plyr <- plyrs do
+          insert(:roster_position, fantasy_team: team, fantasy_player: plyr)
+        end
+
+      attrs = %{
+        fantasy_team_id: team.id,
+        fantasy_player_id: add.id,
+        order: 1,
+        status: "cancelled"
+      }
+
+      changeset = DraftQueue.changeset(%DraftQueue{}, attrs)
+
+      assert changeset.valid?
+    end
+
     # test "valid if team needs player to fill sport position" do
     #   league = insert(:fantasy_league)
     #   team_a = insert(:fantasy_team, fantasy_league: league)


### PR DESCRIPTION
* Allow DraftQueue cancellation without validation
* Validation would fail when cancelling a draft queue
* Cancel necessary because all flex spots filled
* Closes #690