### PR TITLE
Order teams on draft page by total draft time

### DIFF
--- a/lib/ex338/draft_pick/clock.ex
+++ b/lib/ex338/draft_pick/clock.ex
@@ -63,7 +63,7 @@ defmodule Ex338.DraftPick.Clock do
   end
 
   defp sort_by_avg_time_on_the_clock(teams) do
-    Enum.sort(teams, &(&1.avg_seconds_on_the_clock <= &2.avg_seconds_on_the_clock))
+    Enum.sort(teams, &(&1.total_seconds_on_the_clock <= &2.total_seconds_on_the_clock))
   end
 
   defp update_draft_status(fantasy_team) do

--- a/lib/ex338_web/templates/draft_pick/team_summary_table.html.leex
+++ b/lib/ex338_web/templates/draft_pick/team_summary_table.html.leex
@@ -3,8 +3,8 @@
     <tr>
       <th>Fantasy Team</th>
       <th>Number of Picks</th>
-      <th>Total Hours On the Clock</th>
       <th>Avg Mins On the Clock</th>
+      <th>Total Hours On the Clock</th>
     </tr>
   </thead>
   <tbody>
@@ -12,8 +12,8 @@
       <tr>
         <td><%= fantasy_team_link(@socket, team) %></td>
         <td><%= team.picks_selected %></td>
-        <td><%= seconds_to_hours(team.total_seconds_on_the_clock) %></td>
         <td><%= seconds_to_mins(team.avg_seconds_on_the_clock) %></td>
+        <td><%= seconds_to_hours(team.total_seconds_on_the_clock) %></td>
       </tr>
     <% end %>
   </tbody>

--- a/test/ex338/draft_pick/clock_test.exs
+++ b/test/ex338/draft_pick/clock_test.exs
@@ -26,7 +26,7 @@ defmodule Ex338.DraftPick.ClockTest do
           fantasy_team_id: 2,
           fantasy_team: team_b,
           fantasy_player_id: 2,
-          seconds_on_the_clock: seconds_in_an_hr
+          seconds_on_the_clock: 3500
         },
         %DraftPick{
           draft_position: 3,
@@ -38,9 +38,9 @@ defmodule Ex338.DraftPick.ClockTest do
         %DraftPick{
           draft_position: 4,
           fantasy_team_id: 2,
-          fantasy_team: team_b,
+          fantasy_team: team_a,
           fantasy_player_id: 4,
-          seconds_on_the_clock: 400
+          seconds_on_the_clock: seconds_in_an_hr
         },
         %DraftPick{
           draft_position: 5,
@@ -58,7 +58,7 @@ defmodule Ex338.DraftPick.ClockTest do
         }
       ]
 
-      [c, a, b] = Clock.calculate_team_data(draft_picks)
+      [c, b, a] = Clock.calculate_team_data(draft_picks)
 
       assert a.id == 1
       assert b.id == 2
@@ -66,17 +66,17 @@ defmodule Ex338.DraftPick.ClockTest do
       assert a.team_name == "A"
       assert b.team_name == "B"
       assert c.team_name == "C"
-      assert a.picks_selected == 2
-      assert b.picks_selected == 2
+      assert a.picks_selected == 3
+      assert b.picks_selected == 1
       assert c.picks_selected == 0
-      assert a.total_seconds_on_the_clock == 300
-      assert b.total_seconds_on_the_clock == 4000
+      assert a.total_seconds_on_the_clock == 3900
+      assert b.total_seconds_on_the_clock == 3500
       assert c.total_seconds_on_the_clock == 0
-      assert a.avg_seconds_on_the_clock == 150
-      assert b.avg_seconds_on_the_clock == 2000
+      assert a.avg_seconds_on_the_clock == 1300
+      assert b.avg_seconds_on_the_clock == 3500
       assert c.avg_seconds_on_the_clock == 0
-      assert a.over_draft_time_limit? == false
-      assert b.over_draft_time_limit? == true
+      assert a.over_draft_time_limit? == true
+      assert b.over_draft_time_limit? == false
       assert c.over_draft_time_limit? == false
     end
 


### PR DESCRIPTION
* Order teams on draft page by total draft time
* New draft rule sets a total time limit, so it is more important.
* Closes #694