### PR TITLE
Fix bug in FantasyTeam.without_player_from_sport/2

### DIFF
--- a/lib/ex338/fantasy_team.ex
+++ b/lib/ex338/fantasy_team.ex
@@ -227,13 +227,16 @@ defmodule Ex338.FantasyTeam do
   end
 
   def without_player_from_sport(query, sport_id) do
+    roster_subquery =
+      RosterPosition
+      |> RosterPosition.by_sports_league(sport_id)
+      |> RosterPosition.all_owned()
+
     from(
       t in query,
-      left_join: r in assoc(t, :roster_positions),
-      on: r.fantasy_team_id == t.id and (r.status == "active" or r.status == "injured_reserve"),
-      left_join: p in assoc(r, :fantasy_player),
-      left_join: s in assoc(p, :sports_league),
-      where: is_nil(r.id) or s.id != ^sport_id
+      left_join: r in subquery(roster_subquery),
+      on: r.fantasy_team_id == t.id,
+      where: is_nil(r.id)
     )
   end
 

--- a/lib/ex338/roster_position.ex
+++ b/lib/ex338/roster_position.ex
@@ -34,12 +34,9 @@ defmodule Ex338.RosterPosition do
   def status_options, do: @status_options
 
   def active_by_sports_league(query, sports_league_id) do
-    from(
-      r in query,
-      join: p in assoc(r, :fantasy_player),
-      where: p.sports_league_id == ^sports_league_id,
-      where: r.status == "active"
-    )
+    query
+    |> all_active()
+    |> by_sports_league(sports_league_id)
   end
 
   def all_active(query) do
@@ -71,6 +68,14 @@ defmodule Ex338.RosterPosition do
       where: f.fantasy_league_id == ^league_id,
       where: r.status == "active",
       preload: [:fantasy_team]
+    )
+  end
+
+  def by_sports_league(query, sports_league_id) do
+    from(
+      r in query,
+      join: p in assoc(r, :fantasy_player),
+      where: p.sports_league_id == ^sports_league_id
     )
   end
 

--- a/test/ex338/draft_pick_test.exs
+++ b/test/ex338/draft_pick_test.exs
@@ -172,6 +172,7 @@ defmodule Ex338.DraftPickTest do
       regular_positions = insert_list(4, :roster_position, fantasy_team: team)
 
       flex_sport = List.first(regular_positions).fantasy_player.sports_league
+      insert(:league_sport, sports_league: flex_sport, fantasy_league: league)
 
       [add | plyrs] = insert_list(5, :fantasy_player, sports_league: flex_sport)
 
@@ -197,8 +198,9 @@ defmodule Ex338.DraftPickTest do
       regular_positions = insert_list(4, :roster_position, fantasy_team: team)
 
       flex_sport = List.first(regular_positions).fantasy_player.sports_league
+      insert(:league_sport, sports_league: flex_sport, fantasy_league: league)
 
-      [add | plyrs] = insert_list(7, :fantasy_player, sports_league: flex_sport)
+      [add | plyrs] = insert_list(6, :fantasy_player, sports_league: flex_sport)
 
       _flex_slots =
         for plyr <- plyrs do
@@ -214,6 +216,10 @@ defmodule Ex338.DraftPickTest do
       changeset = DraftPick.owner_changeset(draft_pick, attrs)
 
       refute changeset.valid?
+
+      assert changeset.errors == [
+               fantasy_player_id: {"No flex position available for this player", []}
+             ]
     end
 
     test "error if available players equal to teams needing to fill league rosters" do
@@ -237,6 +243,11 @@ defmodule Ex338.DraftPickTest do
       changeset = DraftPick.owner_changeset(draft_pick, attrs)
 
       refute changeset.valid?
+
+      assert changeset.errors == [
+               fantasy_player_id:
+                 {"Number of available players equal to number of teams with need", []}
+             ]
     end
 
     test "error if available players less than teams needing to fill league rosters" do
@@ -261,6 +272,11 @@ defmodule Ex338.DraftPickTest do
       changeset = DraftPick.owner_changeset(draft_pick, attrs)
 
       refute changeset.valid?
+
+      assert changeset.errors == [
+               fantasy_player_id:
+                 {"Number of available players equal to number of teams with need", []}
+             ]
     end
 
     test "valid if team needs player to fill sport position" do
@@ -307,6 +323,11 @@ defmodule Ex338.DraftPickTest do
       changeset = DraftPick.owner_changeset(draft_pick, attrs)
 
       refute changeset.valid?
+
+      assert changeset.errors == [
+               fantasy_player_id:
+                 {"Number of available players equal to number of teams with need", []}
+             ]
     end
 
     test "error if available draft pick players less than teams needing to fill league rosters" do
@@ -331,6 +352,11 @@ defmodule Ex338.DraftPickTest do
       changeset = DraftPick.owner_changeset(draft_pick, attrs)
 
       refute changeset.valid?
+
+      assert changeset.errors == [
+               fantasy_player_id:
+                 {"Number of available players equal to number of teams with need", []}
+             ]
     end
 
     test "valid if team needs draft pick player to fill sport position" do

--- a/test/ex338/fantasy_team_repo_test.exs
+++ b/test/ex338/fantasy_team_repo_test.exs
@@ -849,11 +849,11 @@ defmodule Ex338.FantasyTeamRepoTest do
 
   describe "without_player_from_sport/1" do
     test "returns teams who don't own a player from a sport" do
-      team_with_plyr = insert(:fantasy_team)
-      team_with_two = insert(:fantasy_team)
-      team_with_dropped = insert(:fantasy_team)
-      team_with_other_sport = insert(:fantasy_team)
-      _team_without_plyr = insert(:fantasy_team)
+      team_with_plyr = insert(:fantasy_team, team_name: "A")
+      team_with_two = insert(:fantasy_team, team_name: "B")
+      team_with_dropped = insert(:fantasy_team, team_name: "C")
+      team_with_other_sport = insert(:fantasy_team, team_name: "D")
+      _team_without_plyr = insert(:fantasy_team, team_name: "E")
 
       sport = insert(:sports_league)
       player1 = insert(:fantasy_player, sports_league: sport)
@@ -863,6 +863,8 @@ defmodule Ex338.FantasyTeamRepoTest do
 
       sport2 = insert(:sports_league)
       player5 = insert(:fantasy_player, sports_league: sport2)
+      player6 = insert(:fantasy_player, sports_league: sport2)
+      player7 = insert(:fantasy_player, sports_league: sport2)
 
       insert(:roster_position,
         fantasy_team: team_with_plyr,
@@ -891,6 +893,18 @@ defmodule Ex338.FantasyTeamRepoTest do
       insert(:roster_position,
         fantasy_team: team_with_other_sport,
         fantasy_player: player5,
+        status: "active"
+      )
+
+      insert(:roster_position,
+        fantasy_team: team_with_plyr,
+        fantasy_player: player6,
+        status: "active"
+      )
+
+      insert(:roster_position,
+        fantasy_team: team_with_other_sport,
+        fantasy_player: player7,
         status: "active"
       )
 

--- a/test/ex338/roster_position_repo_test.exs
+++ b/test/ex338/roster_position_repo_test.exs
@@ -125,6 +125,24 @@ defmodule Ex338.RosterPositionRepoTest do
     end
   end
 
+  describe "by_sports_league/2" do
+    test "only returns active roster positions from a sport" do
+      league = insert(:sports_league)
+      other_league = insert(:sports_league)
+      player_a = insert(:fantasy_player, sports_league: league)
+      player_b = insert(:fantasy_player, sports_league: other_league)
+      pos = insert(:roster_position, fantasy_player: player_a)
+      insert(:roster_position, fantasy_player: player_b)
+
+      result =
+        RosterPosition
+        |> RosterPosition.by_sports_league(league.id)
+        |> Repo.one()
+
+      assert result.id == pos.id
+    end
+  end
+
   describe "count_positions_for_team" do
     test "counts the active positions on a fantasy team" do
       team = insert(:fantasy_team)


### PR DESCRIPTION
* Fix bug in FantasyTeam.without_player_from_sport/2
* Query returned too many teams causing draft pick validation to fail
* Updated to use RosterPosition queries as a subquery
* Updated DraftPick tests to assert against specfic errors
* Fixed DraftPick test setup to add league_sport
* Closes #699