### PR TITLE
Add ability to adjust total draft time for team

### DIFF
--- a/lib/ex338/draft_pick/clock.ex
+++ b/lib/ex338/draft_pick/clock.ex
@@ -33,6 +33,9 @@ defmodule Ex338.DraftPick.Clock do
   end
 
   defp sum_data_for_teams({team, team_picks}) do
+    total_draft_secs_adj = team.total_draft_mins_adj * 60
+    team = %{team | total_seconds_on_the_clock: total_draft_secs_adj}
+
     Enum.reduce(team_picks, team, &update_seconds_and_picks/2)
   end
 

--- a/lib/ex338/fantasy_team.ex
+++ b/lib/ex338/fantasy_team.ex
@@ -24,6 +24,7 @@ defmodule Ex338.FantasyTeam do
     field(:slot_results, {:array, :map}, virtual: true, default: [])
     field(:total_seconds_on_the_clock, :integer, virtual: true, default: 0)
     field(:avg_seconds_on_the_clock, :integer, virtual: true, default: 0)
+    field(:total_draft_mins_adj, :integer, default: 0)
     field(:picks_selected, :integer, virtual: true, default: 0)
     field(:over_draft_time_limit?, :boolean, virtual: true, default: false)
     belongs_to(:fantasy_league, Ex338.FantasyLeague)
@@ -83,6 +84,7 @@ defmodule Ex338.FantasyTeam do
       :dues_paid,
       :fantasy_league_id,
       :team_name,
+      :total_draft_mins_adj,
       :waiver_position,
       :winnings_adj,
       :winnings_received

--- a/lib/ex338_web/admin/fantasy_team.ex
+++ b/lib/ex338_web/admin/fantasy_team.ex
@@ -11,6 +11,7 @@ defmodule Ex338Web.ExAdmin.FantasyTeam do
         row(:waiver_position)
         row(:fantasy_league)
         row(:autodraft_setting)
+        row(:total_draft_mins_adj)
         row(:winnings_adj)
         row(:dues_paid)
         row(:winnings_received)

--- a/priv/repo/migrations/20190922222537_add_total_draft_mins_adj_to_fantasy_team.exs
+++ b/priv/repo/migrations/20190922222537_add_total_draft_mins_adj_to_fantasy_team.exs
@@ -1,0 +1,9 @@
+defmodule Ex338.Repo.Migrations.AddTotalDraftMinsAdjToFantasyTeam do
+  use Ecto.Migration
+
+  def change do
+    alter table(:fantasy_teams) do
+      add(:total_draft_mins_adj, :integer, default: 0)
+    end
+  end
+end

--- a/test/ex338/draft_pick/clock_test.exs
+++ b/test/ex338/draft_pick/clock_test.exs
@@ -110,6 +110,57 @@ defmodule Ex338.DraftPick.ClockTest do
       assert a.over_draft_time_limit? == false
       assert b.over_draft_time_limit? == false
     end
+
+    test "adjusts total_seconds_on_the_clock from for team" do
+      league = %FantasyLeague{max_draft_hours: 1}
+
+      team_a = %FantasyTeam{
+        id: 1,
+        team_name: "A",
+        fantasy_league: league,
+        total_draft_mins_adj: -10
+      }
+
+      seconds_in_an_hr = 3600
+
+      draft_picks = [
+        %DraftPick{
+          draft_position: 1,
+          fantasy_team_id: 1,
+          fantasy_team: team_a,
+          fantasy_player_id: 1,
+          seconds_on_the_clock: 0
+        },
+        %DraftPick{
+          draft_position: 3,
+          fantasy_team_id: 1,
+          fantasy_team: team_a,
+          fantasy_player_id: 3,
+          seconds_on_the_clock: 300
+        },
+        %DraftPick{
+          draft_position: 4,
+          fantasy_team_id: 2,
+          fantasy_team: team_a,
+          fantasy_player_id: 4,
+          seconds_on_the_clock: seconds_in_an_hr
+        },
+        %DraftPick{
+          draft_position: 5,
+          fantasy_team_id: 1,
+          fantasy_team: team_a,
+          fantasy_player_id: nil,
+          seconds_on_the_clock: nil
+        }
+      ]
+
+      [a] = Clock.calculate_team_data(draft_picks)
+
+      assert a.picks_selected == 3
+      assert a.total_seconds_on_the_clock == 3300
+      assert a.avg_seconds_on_the_clock == 1100
+      assert a.over_draft_time_limit? == false
+    end
   end
 
   describe "update_seconds_on_the_clock/1" do


### PR DESCRIPTION
* Add ability to adjust total draft time for teams
* Issues outside of owner control often delay their draft pick
* Feature will allow commish to adjust total draft time
* Closes #701