### PR TITLE
Remove start_year & end_year and update seeds

### DIFF
--- a/lib/ex338/fantasy_player.ex
+++ b/lib/ex338/fantasy_player.ex
@@ -8,8 +8,6 @@ defmodule Ex338.FantasyPlayer do
   schema "fantasy_players" do
     field(:player_name, :string)
     field(:draft_pick, :boolean)
-    field(:start_year, :integer)
-    field(:end_year, :integer)
     field(:available_starting_at, :utc_datetime)
     field(:archived_at, :utc_datetime)
     belongs_to(:sports_league, Ex338.SportsLeague)
@@ -38,8 +36,6 @@ defmodule Ex338.FantasyPlayer do
       :player_name,
       :draft_pick,
       :sports_league_id,
-      :start_year,
-      :end_year,
       :available_starting_at,
       :archived_at
     ])

--- a/priv/repo/migrations/20200218020811_delete_unused_fantasy_players_fields.exs
+++ b/priv/repo/migrations/20200218020811_delete_unused_fantasy_players_fields.exs
@@ -1,0 +1,17 @@
+defmodule Ex338.Repo.Migrations.DeleteUnusedFantasyPlayersFields do
+  use Ecto.Migration
+
+  def up do
+    alter table(:fantasy_players) do
+      remove(:start_year)
+      remove(:end_year)
+    end
+  end
+
+  def down do
+    alter table(:fantasy_players) do
+      add(:start_year, :integer, default: 2017)
+      add(:end_year, :integer)
+    end
+  end
+end

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -15,7 +15,7 @@
 defmodule Ex338.Seeds do
   @moduledoc false
 
-  alias Ex338.{FantasyPlayer,SportsLeague, Repo, Championship, CalendarAssistant}
+  alias Ex338.{FantasyPlayer, SportsLeague, Repo, Championship, CalendarAssistant}
 
   def store_sports_leagues(row) do
     changeset = SportsLeague.changeset(%SportsLeague{}, row)
@@ -28,44 +28,62 @@ defmodule Ex338.Seeds do
     Repo.insert!(changeset)
   end
 
-  defp convert_championship_dates(%{
-    trade_deadline_at: trade_days,
-    waiver_deadline_at: waiver_days,
-    championship_at: champ_days
-  } = championship) do
-
-    %{championship |
-      trade_deadline_at: to_date(trade_days),
-      waiver_deadline_at: to_date(waiver_days),
-      championship_at: to_date(champ_days)}
+  defp convert_championship_dates(
+         %{
+           trade_deadline_at: trade_days,
+           waiver_deadline_at: waiver_days,
+           championship_at: champ_days
+         } = championship
+       ) do
+    %{
+      championship
+      | trade_deadline_at: to_date(trade_days),
+        waiver_deadline_at: to_date(waiver_days),
+        championship_at: to_date(champ_days)
+    }
   end
 
   defp to_date(days) do
-     days
-     |> String.to_integer
-     |> CalendarAssistant.days_from_now
+    days
+    |> String.to_integer()
+    |> CalendarAssistant.days_from_now()
   end
 
   def store_fantasy_players(row) do
+    {:ok, start, _} = DateTime.from_iso8601("2017-01-01T00:00:00Z")
+    row = Map.put(row, :available_starting_at, start)
+
     changeset = FantasyPlayer.changeset(%FantasyPlayer{}, row)
     Repo.insert!(changeset)
   end
 end
 
 File.stream!("priv/repo/csv_seed_data/sports_leagues.csv")
-  |> Stream.drop(1)
-  |> CSV.decode!(headers: [:league_name, :abbrev])
-  |> Enum.each(&Ex338.Seeds.store_sports_leagues/1)
+|> Stream.drop(1)
+|> CSV.decode!(headers: [:league_name, :abbrev])
+|> Enum.each(&Ex338.Seeds.store_sports_leagues/1)
 
 File.stream!("priv/repo/csv_seed_data/championships.csv")
-  |> Stream.drop(1)
-  |> CSV.decode!(headers: [:title, :category,  :waiver_deadline_at,
-                          :trade_deadline_at, :championship_at,
-                          :sports_league_id, :overall_id, :in_season_draft,
-                          :year, :waiver_date, :trade_date, :champ_date])
-  |> Enum.each(&Ex338.Seeds.store_championships/1)
+|> Stream.drop(1)
+|> CSV.decode!(
+  headers: [
+    :title,
+    :category,
+    :waiver_deadline_at,
+    :trade_deadline_at,
+    :championship_at,
+    :sports_league_id,
+    :overall_id,
+    :in_season_draft,
+    :year,
+    :waiver_date,
+    :trade_date,
+    :champ_date
+  ]
+)
+|> Enum.each(&Ex338.Seeds.store_championships/1)
 
 File.stream!("priv/repo/csv_seed_data/fantasy_players.csv")
-  |> Stream.drop(1)
-  |> CSV.decode!(headers: [:player_name, :sports_league_id, :draft_pick])
-  |> Enum.each(&Ex338.Seeds.store_fantasy_players/1)
+|> Stream.drop(1)
+|> CSV.decode!(headers: [:player_name, :sports_league_id, :draft_pick])
+|> Enum.each(&Ex338.Seeds.store_fantasy_players/1)

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -89,7 +89,6 @@ defmodule Ex338.Factory do
     %Ex338.FantasyPlayer{
       player_name: sequence(:player_name, &"Player ##{&1}"),
       draft_pick: false,
-      start_year: 2017,
       available_starting_at: CalendarAssistant.days_from_now(-365),
       sports_league: build(:sports_league)
     }


### PR DESCRIPTION
* These columns are no longer needed
* Replaced by available_starting_at & archived_at
* Update FantasyPlayer seeds to include available_starting_at
* Used 2017 since just needs to be before season dates
* Closes #664