### PR TITLE
Remove unused coherence tables & columns

### DIFF
--- a/priv/repo/migrations/20200518234631_drop_coherence_invitations_table.exs
+++ b/priv/repo/migrations/20200518234631_drop_coherence_invitations_table.exs
@@ -1,0 +1,19 @@
+defmodule Ex338.Repo.Migrations.DropCoherenceInvitationsTable do
+  use Ecto.Migration
+
+  def up do
+    drop(table(:invitations))
+  end
+
+  def down do
+    create table(:invitations) do
+      add(:name, :string)
+      add(:email, :string)
+      add(:token, :string)
+      timestamps()
+    end
+
+    create(unique_index(:invitations, [:email]))
+    create(index(:invitations, [:token]))
+  end
+end

--- a/priv/repo/migrations/20200518235114_drop_coherence_rememberables_table.exs
+++ b/priv/repo/migrations/20200518235114_drop_coherence_rememberables_table.exs
@@ -1,0 +1,23 @@
+defmodule Ex338.Repo.Migrations.DropCoherenceRememberablesTable do
+  use Ecto.Migration
+
+  def up do
+    drop(table(:rememberables))
+  end
+
+  def down do
+    create table(:rememberables) do
+      add(:series_hash, :string)
+      add(:token_hash, :string)
+      add(:token_created_at, :utc_datetime)
+      add(:user_id, references(:users, on_delete: :delete_all))
+
+      timestamps()
+    end
+
+    create(index(:rememberables, [:user_id]))
+    create(index(:rememberables, [:series_hash]))
+    create(index(:rememberables, [:token_hash]))
+    create(unique_index(:rememberables, [:user_id, :series_hash, :token_hash]))
+  end
+end

--- a/priv/repo/migrations/20200518235225_remove_coherence_user_columns.exs
+++ b/priv/repo/migrations/20200518235225_remove_coherence_user_columns.exs
@@ -1,0 +1,45 @@
+defmodule Ex338.Repo.Migrations.RemoveCoherenceUserColumns do
+  use Ecto.Migration
+
+  def up do
+    alter table(:users) do
+      # rememberable
+      remove(:remember_created_at)
+      # recoverable
+      remove(:reset_password_token)
+      remove(:reset_password_sent_at)
+      # lockable
+      remove(:failed_attempts)
+      remove(:locked_at)
+      # trackable
+      remove(:sign_in_count)
+      remove(:current_sign_in_at)
+      remove(:last_sign_in_at)
+      remove(:current_sign_in_ip)
+      remove(:last_sign_in_ip)
+      # unlockable_with_token
+      remove(:unlock_token)
+    end
+  end
+
+  def down do
+    alter table(:users) do
+      # rememberable
+      add(:remember_created_at, :utc_datetime)
+      # recoverable
+      add(:reset_password_token, :string)
+      add(:reset_password_sent_at, :utc_datetime)
+      # lockable
+      add(:failed_attempts, :integer, default: 0)
+      add(:locked_at, :utc_datetime)
+      # trackable
+      add(:sign_in_count, :integer, default: 0)
+      add(:current_sign_in_at, :utc_datetime)
+      add(:last_sign_in_at, :utc_datetime)
+      add(:current_sign_in_ip, :string)
+      add(:last_sign_in_ip, :string)
+      # unlockable_with_token
+      add(:unlock_token, :string)
+    end
+  end
+end


### PR DESCRIPTION
* Remove unused coherence tables & columns
* invitations and rememberables not used
* Pow uses backend cache rather than regular database
* Only coherence user column used by Pow is password_hash
* Closes #633