### PR TITLE
Fix test with intermittent failures

### DIFF
--- a/test/ex338/waiver_test.exs
+++ b/test/ex338/waiver_test.exs
@@ -247,7 +247,7 @@ defmodule Ex338.WaiverTest do
       changeset = Waiver.new_changeset(%Waiver{}, attrs)
 
       process_at = get_field(changeset, :process_at)
-      assert DateTime.diff(process_at, three_days_from_now) < 1
+      assert DateTime.diff(process_at, three_days_from_now) < 2
     end
 
     test "sets process_at waiver deadline if in blind waiver period" do


### PR DESCRIPTION
* Fix test with intermittent failures
* Verified process_at was 3 days if no pending waivers
* Due to processing time, sometimes would round up to 1 sec diff
* No issues if the diff is 2 secons off for 3 day time period
* Closes #703