### PR TITLE
Calculate seconds on the clock for next up

### DIFF
--- a/lib/ex338/draft_pick/clock.ex
+++ b/lib/ex338/draft_pick/clock.ex
@@ -86,21 +86,31 @@ defmodule Ex338.DraftPick.Clock do
 
   ## update_seconds_on_the_clock
 
+  # first pick
   defp calculate_seconds_on_the_clock(pick, :none) do
     {%{pick | seconds_on_the_clock: 0}, pick}
   end
 
-  defp calculate_seconds_on_the_clock(%{fantasy_player_id: nil} = pick, _last_pick) do
+  # haven't picked yet
+  defp calculate_seconds_on_the_clock(%{fantasy_player_id: nil} = pick, %{fantasy_player_id: nil}) do
     {%{pick | seconds_on_the_clock: nil}, pick}
   end
 
-  defp calculate_seconds_on_the_clock(pick, %{drafted_at: nil} = last_pick) do
+  # haven't picked yet, but next up and on the clock
+  defp calculate_seconds_on_the_clock(%{fantasy_player_id: nil} = pick, last_pick) do
+    seconds = DateTime.diff(DateTime.utc_now(), last_pick.drafted_at)
+    {%{pick | seconds_on_the_clock: seconds}, pick}
+  end
+
+  # skipped picks when hasn't been drafted
+  defp calculate_seconds_on_the_clock(pick, %{fantasy_player_id: nil} = last_pick) do
     {%{
        pick
        | seconds_on_the_clock: 0
      }, last_pick}
   end
 
+  # regular picks and skipped picks when < 0
   defp calculate_seconds_on_the_clock(pick, last_pick) do
     case DateTime.diff(pick.drafted_at, last_pick.drafted_at) do
       seconds when seconds < 0 ->

--- a/lib/ex338_web/controllers/waiver_admin_controller.ex
+++ b/lib/ex338_web/controllers/waiver_admin_controller.ex
@@ -30,7 +30,8 @@ defmodule Ex338Web.WaiverAdminController do
         conn
         |> put_flash(:info, "Waiver successfully processed")
         |> redirect(
-          to: Routes.fantasy_league_waiver_path(conn, :index, waiver.fantasy_team.fantasy_league_id)
+          to:
+            Routes.fantasy_league_waiver_path(conn, :index, waiver.fantasy_team.fantasy_league_id)
         )
 
       {:error, _, changeset, _} ->

--- a/lib/ex338_web/controllers/waiver_controller.ex
+++ b/lib/ex338_web/controllers/waiver_controller.ex
@@ -96,7 +96,8 @@ defmodule Ex338Web.WaiverController do
         conn
         |> put_flash(:info, "Waiver successfully updated")
         |> redirect(
-          to: Routes.fantasy_league_waiver_path(conn, :index, waiver.fantasy_team.fantasy_league_id)
+          to:
+            Routes.fantasy_league_waiver_path(conn, :index, waiver.fantasy_team.fantasy_league_id)
         )
 
       {:error, changeset} ->

--- a/test/ex338/autodraft_test.exs
+++ b/test/ex338/autodraft_test.exs
@@ -75,6 +75,7 @@ defmodule Ex338.AutoDraftTest do
           :draft_pick,
           draft_position: 1.01,
           fantasy_player: drafted_player,
+          drafted_at: DateTime.from_naive!(~N[2018-09-21 01:10:02.857392], "Etc/UTC"),
           fantasy_team: team,
           fantasy_league: league
         )
@@ -222,6 +223,7 @@ defmodule Ex338.AutoDraftTest do
           :draft_pick,
           draft_position: 1.01,
           fantasy_player: drafted_player,
+          drafted_at: DateTime.from_naive!(~N[2018-09-21 01:10:02.857392], "Etc/UTC"),
           fantasy_team: team,
           fantasy_league: league
         )
@@ -621,6 +623,7 @@ defmodule Ex338.AutoDraftTest do
           :draft_pick,
           draft_position: 1.01,
           fantasy_player: drafted_player,
+          drafted_at: DateTime.from_naive!(~N[2018-09-21 01:10:02.857392], "Etc/UTC"),
           fantasy_team: team,
           fantasy_league: league
         )
@@ -674,6 +677,7 @@ defmodule Ex338.AutoDraftTest do
           :draft_pick,
           draft_position: 1.01,
           fantasy_player: drafted_player,
+          drafted_at: DateTime.from_naive!(~N[2018-09-21 01:10:02.857392], "Etc/UTC"),
           fantasy_team: team,
           fantasy_league: league
         )
@@ -724,6 +728,7 @@ defmodule Ex338.AutoDraftTest do
           :draft_pick,
           draft_position: 1.01,
           fantasy_player: drafted_player,
+          drafted_at: DateTime.from_naive!(~N[2018-09-21 01:10:02.857392], "Etc/UTC"),
           fantasy_team: team,
           fantasy_league: league
         )

--- a/test/ex338/draft_pick/clock_test.exs
+++ b/test/ex338/draft_pick/clock_test.exs
@@ -199,8 +199,14 @@ defmodule Ex338.DraftPick.ClockTest do
       ]
 
       results = Clock.update_seconds_on_the_clock(draft_picks)
+      [one, two, three, four, on_the_clock, six] = Enum.map(results, & &1.seconds_on_the_clock)
 
-      assert Enum.map(results, & &1.seconds_on_the_clock) == [0, 300, 300, 300, nil, nil]
+      assert one == 0
+      assert two == 300
+      assert three == 300
+      assert four == 300
+      assert on_the_clock > 300
+      assert six == nil
     end
 
     test "calculates and updates seconds on the clock when picks are skipped" do
@@ -227,8 +233,8 @@ defmodule Ex338.DraftPick.ClockTest do
         },
         %DraftPick{
           draft_position: 5,
-          fantasy_player_id: nil,
-          drafted_at: nil
+          fantasy_player_id: 5,
+          drafted_at: DateTime.from_naive!(~N[2018-09-21 01:50:02.857392], "Etc/UTC")
         },
         %DraftPick{
           draft_position: 6,
@@ -238,8 +244,14 @@ defmodule Ex338.DraftPick.ClockTest do
       ]
 
       results = Clock.update_seconds_on_the_clock(draft_picks)
+      [one, two, three, four, five, on_the_clock] = Enum.map(results, & &1.seconds_on_the_clock)
 
-      assert Enum.map(results, & &1.seconds_on_the_clock) == [0, 1200, 0, 0, nil, nil]
+      assert one == 0
+      assert two == 1200
+      assert three == 0
+      assert four == 0
+      assert five == 1200
+      assert on_the_clock > 1200
     end
 
     test "calculates seconds on the clock when picks are skipped and haven't been made" do
@@ -277,8 +289,14 @@ defmodule Ex338.DraftPick.ClockTest do
       ]
 
       results = Clock.update_seconds_on_the_clock(draft_picks)
+      [one, on_the_clock, three, four, five, six] = Enum.map(results, & &1.seconds_on_the_clock)
 
-      assert Enum.map(results, & &1.seconds_on_the_clock) == [0, nil, 0, 0, nil, nil]
+      assert one == 0
+      assert on_the_clock > 1200
+      assert three == 0
+      assert four == 0
+      assert five == nil
+      assert six == nil
     end
   end
 

--- a/test/ex338_web/controllers/draft_pick_controller_test.exs
+++ b/test/ex338_web/controllers/draft_pick_controller_test.exs
@@ -64,6 +64,7 @@ defmodule Ex338Web.DraftPickControllerTest do
         draft_position: 1.01,
         fantasy_team: team,
         fantasy_league: league,
+        drafted_at: DateTime.from_naive!(~N[2018-09-21 01:10:02.857392], "Etc/UTC"),
         fantasy_player: player
       )
 
@@ -76,6 +77,7 @@ defmodule Ex338Web.DraftPickControllerTest do
         draft_position: 1.02,
         fantasy_team: team,
         fantasy_league: league,
+        drafted_at: DateTime.from_naive!(~N[2018-09-21 01:15:02.857392], "Etc/UTC"),
         fantasy_player: other_player
       )
 
@@ -85,6 +87,7 @@ defmodule Ex338Web.DraftPickControllerTest do
 
       insert_list(5, :submitted_pick,
         draft_position: 1.03,
+        drafted_at: DateTime.from_naive!(~N[2018-09-21 01:15:02.857392], "Etc/UTC"),
         fantasy_league: league
       )
 


### PR DESCRIPTION
* Add the current time on the clock for next up
* Otherwise skips don't apply until team makes pick
* Other teams should be able to pick as soon as they are over limit
* Closes #697