### PR TITLE
Add refresh of draft data every 60 s

### DIFF
--- a/lib/ex338/draft_pick/clock.ex
+++ b/lib/ex338/draft_pick/clock.ex
@@ -39,7 +39,7 @@ defmodule Ex338.DraftPick.Clock do
     Enum.reduce(team_picks, team, &update_seconds_and_picks/2)
   end
 
-  defp update_seconds_and_picks(%DraftPick{fantasy_player_id: nil}, team_data) do
+  defp update_seconds_and_picks(%DraftPick{seconds_on_the_clock: nil}, team_data) do
     team_data
   end
 

--- a/priv/repo/dev_seeds.exs
+++ b/priv/repo/dev_seeds.exs
@@ -73,7 +73,12 @@ defmodule Ex338.DevSeeds do
   end
 
   def store_draft_picks(row) do
-    row = Map.put(row, :drafted_at, DateTime.utc_now())
+    row =
+      case row.fantasy_player_id == "" do
+        true -> row
+        false -> Map.put(row, :drafted_at, DateTime.utc_now())
+      end
+
     changeset = DraftPick.changeset(%DraftPick{}, row)
     Repo.insert!(changeset)
   end

--- a/test/ex338/draft_pick/store_test.exs
+++ b/test/ex338/draft_pick/store_test.exs
@@ -235,23 +235,29 @@ defmodule Ex338.DraftPick.StoreTest do
   describe "get_picks_for_league/1" do
     test "returns draft picks in descending order" do
       league = insert(:fantasy_league)
+      player1 = insert(:fantasy_player)
+      player2 = insert(:fantasy_player)
+      player3 = insert(:fantasy_player)
 
       insert(:submitted_pick,
         draft_position: 1.05,
         fantasy_league: league,
-        drafted_at: DateTime.from_naive!(~N[2018-09-21 01:30:02.857392], "Etc/UTC")
+        fantasy_player: player1,
+        drafted_at: DateTime.from_naive!(~N[2018-09-21 01:02:02.857392], "Etc/UTC")
       )
 
       insert(:submitted_pick,
         draft_position: 1.04,
         fantasy_league: league,
+        fantasy_player: player2,
         drafted_at: DateTime.from_naive!(~N[2018-09-21 01:00:02.857392], "Etc/UTC")
       )
 
       insert(:draft_pick,
         draft_position: 1.10,
         fantasy_league: league,
-        drafted_at: nil
+        fantasy_player: player3,
+        drafted_at: DateTime.from_naive!(~N[2018-09-21 01:06:02.857392], "Etc/UTC")
       )
 
       other_league = insert(:fantasy_league)
@@ -262,7 +268,7 @@ defmodule Ex338.DraftPick.StoreTest do
 
       assert Enum.map(picks, & &1.draft_position) == [1.04, 1.05, 1.1]
       assert first_pick.fantasy_league.id == league.id
-      assert Enum.map(teams, & &1.avg_seconds_on_the_clock) == [0, 0, 1800]
+      assert Enum.map(teams, & &1.avg_seconds_on_the_clock) == [0, 120, 240]
     end
   end
 end


### PR DESCRIPTION
* Add refresh of draft data every 60 seconds
* Updates hours on the clock for team up to pick
* Fix bugs in seeds and DraftPick.Clock, see #697
* Closes #823