### PR TITLE
Update waivers to allow cancellation

### DIFF
--- a/lib/ex338/waiver.ex
+++ b/lib/ex338/waiver.ex
@@ -5,7 +5,9 @@ defmodule Ex338.Waiver do
 
   alias Ex338.{CalendarAssistant, FantasyPlayer, FantasyTeam, Repo, Waiver, Waiver.Validate}
 
-  @status_options ["pending", "successful", "unsuccessful", "invalid"]
+  @status_options ["pending", "successful", "unsuccessful", "invalid", "cancelled"]
+
+  @status_options_for_team_update ["pending", "cancelled"]
 
   schema "waivers" do
     belongs_to(:fantasy_team, Ex338.FantasyTeam)
@@ -100,6 +102,8 @@ defmodule Ex338.Waiver do
   end
 
   def status_options, do: @status_options
+
+  def status_options_for_team_update, do: @status_options_for_team_update
 
   def update_changeset(waiver_struct, params \\ %{}) do
     waiver_struct

--- a/lib/ex338/waiver.ex
+++ b/lib/ex338/waiver.ex
@@ -107,9 +107,11 @@ defmodule Ex338.Waiver do
 
   def update_changeset(waiver_struct, params \\ %{}) do
     waiver_struct
-    |> cast(params, [:drop_fantasy_player_id])
+    |> cast(params, [:drop_fantasy_player_id, :status])
     |> foreign_key_constraint(:drop_fantasy_player_id)
     |> Validate.wait_period_open()
+    |> Validate.within_cancellation_period()
+    |> validate_inclusion(:status, status_options_for_team_update())
   end
 
   ## Helpers

--- a/lib/ex338/waiver/validate.ex
+++ b/lib/ex338/waiver/validate.ex
@@ -101,6 +101,18 @@ defmodule Ex338.Waiver.Validate do
     do_wait_period_open(waiver_changeset, result)
   end
 
+  def within_cancellation_period(waiver_changeset) do
+    submitted_at = waiver_changeset.data.inserted_at
+    now = NaiveDateTime.utc_now()
+    two_hours = 60 * 60 * 2
+    age_of_waiver = NaiveDateTime.diff(now, submitted_at, :second)
+
+    case age_of_waiver < two_hours do
+      true -> waiver_changeset
+      false -> add_error(waiver_changeset, :status, "Must cancel within two hours of submitting")
+    end
+  end
+
   ## Helpers
 
   ## add_or_drop

--- a/lib/ex338_web/templates/waiver/edit.html.eex
+++ b/lib/ex338_web/templates/waiver/edit.html.eex
@@ -1,4 +1,4 @@
-<h3>Update Player to Drop</h3>
+<h3>Update Waiver</h3>
 <p><strong>Fantasy Team: </strong><%= @waiver.fantasy_team.team_name %></p>
 
 <p><strong>Waiver Position: </strong><%= @waiver.fantasy_team.waiver_position %></p>

--- a/lib/ex338_web/templates/waiver/update_form.html.eex
+++ b/lib/ex338_web/templates/waiver/update_form.html.eex
@@ -7,13 +7,20 @@
 
   <div class="form-group">
     <%= label f, :drop_fantasy_player_id, class: "control-label" %>
-    <%= select f, :drop_fantasy_player_id, 
+    <%= select f, :drop_fantasy_player_id,
           format_players_for_select(@owned_players), class: "form-control",
           prompt: "Select a Player to Drop" %>
     <%= error_tag f, :drop_fantasy_player_id %>
   </div>
+  <%= if within_two_hours_of_submittal?(@changeset.data) do %>
+    <div class="form-group">
+      <%= label f, :status, class: "control-label" %>
+      <%= select f, :status, Ex338.Waiver.status_options_for_team_update(), class: "form-control" %>
+      <%= error_tag f, :status %>
+    </div>
+  <% end %>
   </br>
-  
+
   <div class="form-group">
     <%= submit "Submit", class: "btn btn-primary" %>
   </div>

--- a/lib/ex338_web/views/waiver_view.ex
+++ b/lib/ex338_web/views/waiver_view.ex
@@ -13,6 +13,23 @@ defmodule Ex338Web.WaiverView do
     Enum.sort(query, &before_other_date?(&1.process_at, &2.process_at))
   end
 
+  def display_name(%{sports_league: %{hide_waivers: true}}), do: "*****"
+
+  def display_name(%{player_name: name} = _player), do: name
+
+  def within_two_hours_of_submittal?(waiver) do
+    submitted_at = waiver.inserted_at
+    now = NaiveDateTime.utc_now()
+    two_hours = 60 * 60 * 2
+    age_of_waiver = NaiveDateTime.diff(now, submitted_at, :second)
+
+    age_of_waiver < two_hours
+  end
+
+  # Helpers
+
+  # sort_most_recent
+
   defp before_other_date?(date1, date2) do
     case DateTime.compare(date1, date2) do
       :gt -> true
@@ -20,8 +37,4 @@ defmodule Ex338Web.WaiverView do
       :lt -> false
     end
   end
-
-  def display_name(%{sports_league: %{hide_waivers: true}}), do: "*****"
-
-  def display_name(%{player_name: name} = _player), do: name
 end

--- a/test/ex338_web/controllers/waiver_controller_test.exs
+++ b/test/ex338_web/controllers/waiver_controller_test.exs
@@ -181,9 +181,10 @@ defmodule Ex338Web.WaiverControllerTest do
 
       conn = get(conn, waiver_path(conn, :edit, waiver.id))
 
-      assert html_response(conn, 200) =~ ~r/Update Player to Drop/
+      assert html_response(conn, 200) =~ ~r/Update Waiver/
       assert String.contains?(conn.resp_body, team.team_name)
       assert String.contains?(conn.resp_body, player_b.player_name)
+      assert String.contains?(conn.resp_body, "cancelled")
     end
 
     test "redirects to root if user is not owner", %{conn: conn} do

--- a/test/ex338_web/controllers/waiver_controller_test.exs
+++ b/test/ex338_web/controllers/waiver_controller_test.exs
@@ -201,6 +201,29 @@ defmodule Ex338Web.WaiverControllerTest do
       league = insert(:fantasy_league)
       team = insert(:fantasy_team, fantasy_league: league)
       insert(:owner, fantasy_team: team, user: conn.assigns.current_user)
+      player = insert(:fantasy_player)
+
+      waiver =
+        insert(
+          :waiver,
+          fantasy_team: team,
+          drop_fantasy_player: player
+        )
+
+      params = %{drop_fantasy_player_id: player.id, status: "cancelled"}
+
+      conn = patch(conn, waiver_path(conn, :update, waiver.id, waiver: params))
+
+      assert Repo.get!(Waiver, waiver.id).status == "cancelled"
+
+      assert redirected_to(conn) ==
+               fantasy_league_waiver_path(conn, :index, team.fantasy_league_id)
+    end
+
+    test "updates a waiver to cancelled", %{conn: conn} do
+      league = insert(:fantasy_league)
+      team = insert(:fantasy_team, fantasy_league: league)
+      insert(:owner, fantasy_team: team, user: conn.assigns.current_user)
       player_a = insert(:fantasy_player)
       player_b = insert(:fantasy_player)
 

--- a/test/ex338_web/views/waiver_view_test.exs
+++ b/test/ex338_web/views/waiver_view_test.exs
@@ -1,6 +1,6 @@
 defmodule Ex338Web.WaiverViewTest do
   use Ex338Web.ConnCase, async: true
-  alias Ex338.{CalendarAssistant}
+  alias Ex338.{CalendarAssistant, Waiver}
   alias Ex338Web.{WaiverView}
 
   describe "sort_most_recent/1" do
@@ -59,6 +59,30 @@ defmodule Ex338Web.WaiverViewTest do
       result = WaiverView.display_name(player)
 
       assert result == "Michigan"
+    end
+  end
+
+  describe "within_two_hours_of_submittal?/1" do
+    test "returns true if waiver submitted within two hours" do
+      now = NaiveDateTime.utc_now()
+      one_hour = 60 * 60 * -1
+      one_hour_ago = NaiveDateTime.add(now, one_hour)
+      waiver = %Waiver{inserted_at: one_hour_ago}
+
+      result = WaiverView.within_two_hours_of_submittal?(waiver)
+
+      assert result == true
+    end
+
+    test "returns false if waiver submitted more than two hours" do
+      now = NaiveDateTime.utc_now()
+      three_hours = 60 * 60 * 3 * -1
+      three_hours_ago = NaiveDateTime.add(now, three_hours)
+      waiver = %Waiver{inserted_at: three_hours_ago}
+
+      result = WaiverView.within_two_hours_of_submittal?(waiver)
+
+      assert result == false
     end
   end
 end


### PR DESCRIPTION
* Update waiver edit form to allow cancellation
* Not allowed after two hours based on 338 rules
* Validate waiver created within two hours
* Closes #564