### PR TITLE
Only use flex positions when league sets option

### DIFF
--- a/lib/ex338/fantasy_leagues/fantasy_league.ex
+++ b/lib/ex338/fantasy_leagues/fantasy_league.ex
@@ -9,6 +9,8 @@ defmodule Ex338.FantasyLeagues.FantasyLeague do
     field(:fantasy_league_name, :string)
     field(:year, :integer)
     field(:division, :string)
+    field(:only_flex?, :boolean, default: false)
+    field(:must_draft_each_sport?, :boolean, default: false)
     field(:championships_start_at, :utc_datetime)
     field(:championships_end_at, :utc_datetime)
     field(:navbar_display, FantasyLeagueNavbarDisplayEnum, default: "primary")
@@ -40,7 +42,9 @@ defmodule Ex338.FantasyLeagues.FantasyLeague do
       :fantasy_league_name,
       :max_draft_hours,
       :max_flex_spots,
+      :must_draft_each_sport?,
       :navbar_display,
+      :only_flex?,
       :sport_draft_id,
       :year
     ])

--- a/lib/ex338/roster_positions.ex
+++ b/lib/ex338/roster_positions.ex
@@ -35,6 +35,10 @@ defmodule Ex338.RosterPositions do
     |> Repo.all()
   end
 
+  def positions(%FantasyLeague{only_flex?: true, max_flex_spots: max_flex_spots}) do
+    RosterPosition.flex_positions(max_flex_spots)
+  end
+
   def positions(%FantasyLeague{id: fantasy_league_id, max_flex_spots: max_flex_spots}) do
     primary_positions = FantasyPlayers.list_sports_abbrevs(fantasy_league_id)
     primary_positions ++ RosterPosition.flex_positions(max_flex_spots)

--- a/priv/repo/migrations/20200816034556_add_new_options_to_fantasy_league.exs
+++ b/priv/repo/migrations/20200816034556_add_new_options_to_fantasy_league.exs
@@ -1,0 +1,10 @@
+defmodule Ex338.Repo.Migrations.AddNewOptionsToFantasyLeague do
+  use Ecto.Migration
+
+  def change do
+    alter table(:fantasy_leagues) do
+      add(:only_flex?, :boolean, default: false)
+      add(:must_draft_each_sport?, :boolean, default: false)
+    end
+  end
+end

--- a/test/ex338/roster_positions_test.exs
+++ b/test/ex338/roster_positions_test.exs
@@ -140,6 +140,26 @@ defmodule Ex338.RosterPositionsTest do
       assert Enum.any?(result, &(&1 == "Flex5"))
       refute Enum.any?(result, &(&1 == "Flex6"))
     end
+
+    test "returns only flex positions for a league when league has that option" do
+      sport_b = insert(:sports_league, abbrev: "b")
+      sport_c = insert(:sports_league, abbrev: "c")
+      sport_a = insert(:sports_league, abbrev: "a")
+      insert(:sports_league, abbrev: "z")
+
+      league = insert(:fantasy_league, max_flex_spots: 5, only_flex?: true)
+
+      insert(:league_sport, fantasy_league: league, sports_league: sport_a)
+      insert(:league_sport, fantasy_league: league, sports_league: sport_b)
+      insert(:league_sport, fantasy_league: league, sports_league: sport_c)
+
+      result = RosterPositions.positions(league)
+
+      assert Enum.count(result) == 5
+      refute Enum.any?(result, &(&1 == sport_a.abbrev))
+      assert Enum.any?(result, &(&1 == "Flex5"))
+      refute Enum.any?(result, &(&1 == "Flex6"))
+    end
   end
 
   describe "positions_for_draft/2" do

--- a/test/ex338_web/controllers/fantasy_team_controller_test.exs
+++ b/test/ex338_web/controllers/fantasy_team_controller_test.exs
@@ -169,6 +169,21 @@ defmodule Ex338Web.FantasyTeamControllerTest do
       refute String.contains?(conn.resp_body, dropped_player.player_name)
     end
 
+    test "shows only flex positions in roster when league has that option", %{conn: conn} do
+      league = insert(:fantasy_league, only_flex?: true)
+      team = insert(:fantasy_team, fantasy_league: league)
+
+      insert(:owner, user: conn.assigns.current_user, fantasy_team: team)
+
+      sport = insert(:sports_league, abbrev: "My Sport")
+      insert(:championship, sports_league: sport)
+      insert(:league_sport, fantasy_league: league, sports_league: sport)
+
+      conn = get(conn, fantasy_team_path(conn, :show, team.id))
+
+      refute String.contains?(conn.resp_body, sport.abbrev)
+    end
+
     test "shows fantasy team championship with events results", %{conn: conn} do
       league = insert(:fantasy_league)
       team = insert(:fantasy_team, team_name: "Brown", fantasy_league: league)


### PR DESCRIPTION
* Only use flex positions when league sets option `only_flex?: true`
* 2021 season will only use flex positions
* See #900