### PR TITLE
Fix bug in team edit page

### DIFF
--- a/lib/ex338_web/views/fantasy_team_view.ex
+++ b/lib/ex338_web/views/fantasy_team_view.ex
@@ -47,6 +47,10 @@ defmodule Ex338Web.FantasyTeamView do
     end
   end
 
+  def position_selections(_, %FantasyLeague{only_flex?: true, max_flex_spots: num_spots}) do
+    RosterPosition.flex_positions(num_spots)
+  end
+
   def position_selections(position_form_struct, %FantasyLeague{max_flex_spots: num_spots}) do
     [position_form_struct.data.fantasy_player.sports_league.abbrev] ++
       RosterPosition.flex_positions(num_spots)

--- a/test/ex338_web/views/fantasy_team_view_test.exs
+++ b/test/ex338_web/views/fantasy_team_view_test.exs
@@ -133,11 +133,21 @@ defmodule Ex338Web.FantasyTeamViewTest do
     test "returns sports league abbrev and flex positions" do
       pos_form_struct = %{data: %{fantasy_player: %{sports_league: %{abbrev: "CBB"}}}}
 
-      league = %FantasyLeague{id: 1, max_flex_spots: 2}
+      league = %FantasyLeague{id: 1, max_flex_spots: 2, only_flex?: false}
 
       results = FantasyTeamView.position_selections(pos_form_struct, league)
 
       assert results == ["CBB", "Flex1", "Flex2"]
+    end
+
+    test "returns only flex positions based on league settings" do
+      pos_form_struct = %{data: %{fantasy_player: %{sports_league: %{abbrev: "CBB"}}}}
+
+      league = %FantasyLeague{id: 1, max_flex_spots: 2, only_flex?: true}
+
+      results = FantasyTeamView.position_selections(pos_form_struct, league)
+
+      assert results == ["Flex1", "Flex2"]
     end
   end
 


### PR DESCRIPTION
* When `only_flex?` is true, should only show flex
* Fix bug where primary position included in options
* Closes #927