### PR TITLE
Add word-break for fantasy team names

### DIFF
--- a/lib/ex338_web/templates/draft_pick/current_table.html.leex
+++ b/lib/ex338_web/templates/draft_pick/current_table.html.leex
@@ -27,7 +27,7 @@
         <%= table_td do %>
           <%= draft_pick.draft_position %>
         <% end %>
-        <%= table_td do %>
+        <%= table_td style: "word-break: break-word;" do %>
           <%= if draft_pick.fantasy_team do %>
             <%= fantasy_team_link(@socket, draft_pick.fantasy_team) %>
           <% end %>

--- a/lib/ex338_web/templates/draft_pick/table.html.leex
+++ b/lib/ex338_web/templates/draft_pick/table.html.leex
@@ -27,7 +27,7 @@
         <%= table_td do %>
           <%= draft_pick.draft_position %>
         <% end %>
-        <%= table_td do %>
+        <%= table_td style: "word-break: break-word;" do %>
           <%= if draft_pick.fantasy_team do %>
             <%= fantasy_team_link(@socket, draft_pick.fantasy_team) %>
           <% end %>

--- a/lib/ex338_web/templates/draft_pick/team_summary_table.html.leex
+++ b/lib/ex338_web/templates/draft_pick/team_summary_table.html.leex
@@ -18,7 +18,7 @@
   <tbody class="bg-white">
     <%= for team <- @fantasy_teams do %>
       <tr>
-        <%= table_td do %>
+        <%= table_td style: "word-break: break-word;" do %>
           <%= fantasy_team_link(@socket, team) %>
         <% end %>
         <%= table_td class: "text-center" do %>

--- a/lib/ex338_web/templates/fantasy_league/fantasy_teams_table.html.eex
+++ b/lib/ex338_web/templates/fantasy_league/fantasy_teams_table.html.eex
@@ -33,7 +33,7 @@
               <td class="px-1 py-2 text-sm text-center text-gray-500 whitespace-no-wrap border-b border-gray-200 sm:px-6 lg:text-base sm:text-left leading-5">
                 <%= team.rank %>
               </td>
-              <td class="px-1 py-2 text-sm font-medium text-indigo-700 break-words border-b border-gray-200 sm:px-6 lg:text-base leading-5">
+              <td class="px-1 py-2 text-sm font-medium text-indigo-700 break-words border-b border-gray-200 sm:px-6 lg:text-base leading-5" style="word-break: break-word;">
                 <%= link team.team_name, to: Routes.fantasy_team_path(@conn, :show, team.id) %>
               </td>
               <td class="px-1 py-2 text-sm text-center text-gray-500 whitespace-no-wrap border-b border-gray-200 sm:px-6 lg:text-base leading-5">


### PR DESCRIPTION
* Add word-break for fantasy team names in draft & fantasy league tables
* Long team names cause overflow
* Closes #938