### PR TITLE
Fix bug with InjuredReserve update error handling

### DIFF
--- a/lib/ex338/injured_reserves/admin.ex
+++ b/lib/ex338/injured_reserves/admin.ex
@@ -68,7 +68,7 @@ defmodule Ex338.InjuredReserves.Admin do
     Multi.update(
       multi,
       :update_position_to_active,
-      RosterPosition.changeset(position, %{"status" => "active"})
+      RosterPosition.changeset(position, %{"status" => "active", "position" => "Unassigned"})
     )
   end
 

--- a/lib/ex338_web/controllers/injured_reserve_controller.ex
+++ b/lib/ex338_web/controllers/injured_reserve_controller.ex
@@ -27,11 +27,19 @@ defmodule Ex338Web.InjuredReserveController do
         |> redirect(to: Routes.fantasy_league_injured_reserve_path(conn, :index, league_id))
 
       {:error, _action, error, _} ->
-        Logger.error(inspect(error))
-
         conn
-        |> put_flash(:error, "Error processing IR")
+        |> put_flash(:error, parse_errors(error))
         |> redirect(to: Routes.fantasy_league_injured_reserve_path(conn, :index, league_id))
     end
+  end
+
+  # Helpers
+
+  defp parse_errors(error) when is_binary(error), do: error
+
+  defp parse_errors(changeset) do
+    Enum.reduce(changeset.errors, "", fn {_field, {error, _details}}, message ->
+      error <> " " <> message
+    end)
   end
 end

--- a/test/ex338/injured_reserves_test.exs
+++ b/test/ex338/injured_reserves_test.exs
@@ -197,5 +197,44 @@ defmodule Ex338.InjuredReservesTest do
 
       assert ir.status == :returned
     end
+
+    test "updates injured reserve status to returned when positions is taken" do
+      league = insert(:fantasy_league)
+      team = insert(:fantasy_team, fantasy_league: league)
+      player_a = insert(:fantasy_player)
+      player_b = insert(:fantasy_player)
+
+      insert(:roster_position,
+        position: "sport",
+        fantasy_team: team,
+        fantasy_player: player_a,
+        status: "injured_reserve"
+      )
+
+      ir =
+        insert(
+          :injured_reserve,
+          injured_player: player_a,
+          fantasy_team: team,
+          replacement_player: player_b,
+          status: "approved"
+        )
+
+      insert(:roster_position,
+        position: "sport",
+        fantasy_team: team,
+        fantasy_player: player_b,
+        status: "active"
+      )
+
+      attrs = %{"status" => "returned"}
+
+      {:ok,
+       %{
+         injured_reserve: ir
+       }} = InjuredReserves.update_injured_reserve(ir, attrs)
+
+      assert ir.status == :returned
+    end
   end
 end

--- a/test/ex338_web/controllers/injured_reserve_controller_test.exs
+++ b/test/ex338_web/controllers/injured_reserve_controller_test.exs
@@ -108,55 +108,6 @@ defmodule Ex338Web.InjuredReserveControllerTest do
       assert Repo.get!(InjuredReserve, ir.id).status == :submitted
     end
 
-    test "handles changeset error", %{conn: conn} do
-      conn = put_in(conn.assigns.current_user.admin, true)
-      league = insert(:fantasy_league)
-      team = insert(:fantasy_team, fantasy_league: league)
-      player_a = insert(:fantasy_player)
-      player_b = insert(:fantasy_player)
-
-      insert(:roster_position,
-        position: "sport",
-        fantasy_team: team,
-        fantasy_player: player_a,
-        status: "injured_reserve"
-      )
-
-      ir =
-        insert(
-          :injured_reserve,
-          injured_player: player_a,
-          fantasy_team: team,
-          replacement_player: player_b,
-          status: "approved"
-        )
-
-      insert(:roster_position,
-        position: "sport",
-        fantasy_team: team,
-        fantasy_player: player_b,
-        status: "active"
-      )
-
-      conn =
-        patch(
-          conn,
-          fantasy_league_injured_reserve_path(conn, :update, league.id, ir.id, %{
-            "injured_reserve" => %{"status" => "returned"}
-          })
-        )
-
-      assert redirected_to(conn) ==
-               fantasy_league_injured_reserve_path(
-                 conn,
-                 :index,
-                 team.fantasy_league_id
-               )
-
-      assert get_flash(conn, :error) == "Already have a player in this position "
-      assert Repo.get!(InjuredReserve, ir.id).status == :approved
-    end
-
     test "redirects to root if user is not admin", %{conn: conn} do
       league = insert(:fantasy_league)
       team = insert(:fantasy_team, fantasy_league: league)

--- a/test/ex338_web/controllers/injured_reserve_controller_test.exs
+++ b/test/ex338_web/controllers/injured_reserve_controller_test.exs
@@ -104,8 +104,57 @@ defmodule Ex338Web.InjuredReserveControllerTest do
           })
         )
 
-      assert get_flash(conn, :error) == "Error processing IR"
+      assert get_flash(conn, :error) == "No roster position found for IR."
       assert Repo.get!(InjuredReserve, ir.id).status == :submitted
+    end
+
+    test "handles changeset error", %{conn: conn} do
+      conn = put_in(conn.assigns.current_user.admin, true)
+      league = insert(:fantasy_league)
+      team = insert(:fantasy_team, fantasy_league: league)
+      player_a = insert(:fantasy_player)
+      player_b = insert(:fantasy_player)
+
+      insert(:roster_position,
+        position: "sport",
+        fantasy_team: team,
+        fantasy_player: player_a,
+        status: "injured_reserve"
+      )
+
+      ir =
+        insert(
+          :injured_reserve,
+          injured_player: player_a,
+          fantasy_team: team,
+          replacement_player: player_b,
+          status: "approved"
+        )
+
+      insert(:roster_position,
+        position: "sport",
+        fantasy_team: team,
+        fantasy_player: player_b,
+        status: "active"
+      )
+
+      conn =
+        patch(
+          conn,
+          fantasy_league_injured_reserve_path(conn, :update, league.id, ir.id, %{
+            "injured_reserve" => %{"status" => "returned"}
+          })
+        )
+
+      assert redirected_to(conn) ==
+               fantasy_league_injured_reserve_path(
+                 conn,
+                 :index,
+                 team.fantasy_league_id
+               )
+
+      assert get_flash(conn, :error) == "Already have a player in this position "
+      assert Repo.get!(InjuredReserve, ir.id).status == :approved
     end
 
     test "redirects to root if user is not admin", %{conn: conn} do


### PR DESCRIPTION
* Fix bug with InjuredReserve update error handling
* Shouldn't pass changeset to put_flash/2
* Causes cookie overflow
* Closes #956