### PR TITLE
Remove 2 hr cancellation limit for waivers

### DIFF
--- a/lib/ex338/waivers/validate.ex
+++ b/lib/ex338/waivers/validate.ex
@@ -5,7 +5,13 @@ defmodule Ex338.Waivers.Validate do
   import Ecto.Changeset
   import Ecto.Query, warn: false
 
-  alias Ex338.{FantasyPlayers, FantasyTeams, Repo, RosterPositions.RosterPosition, ValidateHelpers}
+  alias Ex338.{
+    FantasyPlayers,
+    FantasyTeams,
+    Repo,
+    RosterPositions.RosterPosition,
+    ValidateHelpers
+  }
 
   def add_or_drop(waiver_changeset) do
     add_player = fetch_change(waiver_changeset, :add_fantasy_player_id)
@@ -101,18 +107,6 @@ defmodule Ex338.Waivers.Validate do
     result = DateTime.compare(process_at, now)
 
     do_wait_period_open(waiver_changeset, result)
-  end
-
-  def within_cancellation_period(waiver_changeset) do
-    submitted_at = waiver_changeset.data.inserted_at
-    now = NaiveDateTime.utc_now()
-    two_hours = 60 * 60 * 2
-    age_of_waiver = NaiveDateTime.diff(now, submitted_at, :second)
-
-    case age_of_waiver < two_hours do
-      true -> waiver_changeset
-      false -> add_error(waiver_changeset, :status, "Must cancel within two hours of submitting")
-    end
   end
 
   ## Helpers

--- a/lib/ex338/waivers/waiver.ex
+++ b/lib/ex338/waivers/waiver.ex
@@ -120,7 +120,6 @@ defmodule Ex338.Waivers.Waiver do
     |> cast(params, [:drop_fantasy_player_id, :status])
     |> foreign_key_constraint(:drop_fantasy_player_id)
     |> Validate.wait_period_open()
-    |> Validate.within_cancellation_period()
     |> validate_inclusion(:status, status_options_for_team_update())
   end
 

--- a/lib/ex338_web/templates/waiver/update_form.html.eex
+++ b/lib/ex338_web/templates/waiver/update_form.html.eex
@@ -36,14 +36,12 @@
                   prompt: "Select player to drop"
                 %>
 
-                <%= if within_two_hours_of_submittal?(@changeset.data) do %>
-                  <%=
-                    input f,
-                    :status,
-                    using: :select,
-                    select_options: Ex338.Waivers.Waiver.status_options_for_team_update()
-                  %>
-                <% end %>
+                <%=
+                  input f,
+                  :status,
+                  using: :select,
+                  select_options: Ex338.Waivers.Waiver.status_options_for_team_update()
+                %>
               </div>
             </div>
           </div>

--- a/test/ex338/waivers/waiver_test.exs
+++ b/test/ex338/waivers/waiver_test.exs
@@ -672,32 +672,6 @@ defmodule Ex338.Waivers.WaiverTest do
       refute changeset.valid?
     end
 
-    test "does not allow waiver cancelled after two hours of submittal" do
-      now = NaiveDateTime.utc_now()
-      three_hours = 60 * 60 * 3 * -1
-      three_hours_ago = NaiveDateTime.add(now, three_hours)
-
-      waiver = insert(:waiver, inserted_at: three_hours_ago)
-      attrs = %{status: "cancelled"}
-
-      changeset = Waiver.update_changeset(waiver, attrs)
-
-      refute changeset.valid?
-    end
-
-    test "does allow waiver cancelled after one hour of submittal" do
-      now = NaiveDateTime.utc_now()
-      one_hour = 60 * 60 * 1 * -1
-      one_hour_ago = NaiveDateTime.add(now, one_hour)
-
-      waiver = insert(:waiver, inserted_at: one_hour_ago)
-      attrs = %{status: "cancelled"}
-
-      changeset = Waiver.update_changeset(waiver, attrs)
-
-      assert changeset.valid?
-    end
-
     test "invalid if submitted after wait period ends" do
       league = insert(:fantasy_league)
       team = insert(:fantasy_team, fantasy_league: league)


### PR DESCRIPTION
* Remove 2 hr cancellation limit for waivers
* Per discussion with commish, no longer necessary
* Closes #970