### PR TITLE
Include existing draft queue order during edit

### DIFF
--- a/lib/ex338_web/views/fantasy_team_view.ex
+++ b/lib/ex338_web/views/fantasy_team_view.ex
@@ -39,12 +39,21 @@ defmodule Ex338Web.FantasyTeamView do
   def display_points(_), do: ""
 
   def order_range(team_form_struct) do
+    current_order_numbers = Enum.map(team_form_struct.data.draft_queues, & &1.order)
+
     number_of_queues = Enum.count(team_form_struct.data.draft_queues)
 
-    case number_of_queues do
-      0 -> []
-      total -> Enum.to_list(1..total)
-    end
+    count_of_queues =
+      case number_of_queues do
+        0 -> []
+        total -> Enum.to_list(1..total)
+      end
+
+    all_order_numbers = count_of_queues ++ current_order_numbers
+
+    all_order_numbers
+    |> Enum.sort()
+    |> Enum.uniq()
   end
 
   def position_selections(_, %FantasyLeague{only_flex?: true, max_flex_spots: num_spots}) do

--- a/test/ex338_web/views/fantasy_team_view_test.exs
+++ b/test/ex338_web/views/fantasy_team_view_test.exs
@@ -113,11 +113,19 @@ defmodule Ex338Web.FantasyTeamViewTest do
 
   describe "order_range/1" do
     test "returns number of draft queues as a range" do
-      team_form_struct = %{data: %{draft_queues: [%{id: 4}, %{id: 5}]}}
+      team_form_struct = %{data: %{draft_queues: [%{order: 1}, %{order: 2}]}}
 
       results = FantasyTeamView.order_range(team_form_struct)
 
       assert results == [1, 2]
+    end
+
+    test "returns number of draft queues as a range including existing draft queues" do
+      team_form_struct = %{data: %{draft_queues: [%{order: 1}, %{order: 3}]}}
+
+      results = FantasyTeamView.order_range(team_form_struct)
+
+      assert results == [1, 2, 3]
     end
 
     test "returns empty list if no draft queues" do


### PR DESCRIPTION
* Include existing draft queue order during edit
* If you have 3 draft queues and delete #2 then teh next edit has two #1s
* Update function to include existing order numbers