### PR TITLE
Remove draft queue validation for flex spots

### DIFF
--- a/lib/ex338/draft_queues/draft_queue.ex
+++ b/lib/ex338/draft_queues/draft_queue.ex
@@ -50,7 +50,8 @@ defmodule Ex338.DraftQueues.DraftQueue do
     draft_queue
     |> cast(attrs, [:order, :fantasy_team_id, :fantasy_player_id, :status])
     |> validate_required([:order, :fantasy_team_id, :fantasy_player_id])
-    |> DraftPick.validate_max_flex_spots()
+
+    # |> DraftPick.validate_max_flex_spots()
 
     # |> DraftPick.validate_players_available_for_league()
   end

--- a/test/ex338/draft_queues/draft_queue_test.exs
+++ b/test/ex338/draft_queues/draft_queue_test.exs
@@ -152,32 +152,32 @@ defmodule Ex338.DraftQueues.DraftQueueTest do
       assert changeset.valid?
     end
 
-    test "error if too many flex spots in use" do
-      league = insert(:fantasy_league, max_flex_spots: 5)
-      team = insert(:fantasy_team, fantasy_league: league)
-      regular_positions = insert_list(4, :roster_position, fantasy_team: team)
+    # test "error if too many flex spots in use" do
+    #   league = insert(:fantasy_league, max_flex_spots: 5)
+    #   team = insert(:fantasy_team, fantasy_league: league)
+    #   regular_positions = insert_list(4, :roster_position, fantasy_team: team)
 
-      flex_sport = List.first(regular_positions).fantasy_player.sports_league
+    #   flex_sport = List.first(regular_positions).fantasy_player.sports_league
 
-      [add | plyrs] = insert_list(7, :fantasy_player, sports_league: flex_sport)
+    #   [add | plyrs] = insert_list(7, :fantasy_player, sports_league: flex_sport)
 
-      _flex_slots =
-        for plyr <- plyrs do
-          insert(:roster_position, fantasy_team: team, fantasy_player: plyr)
-        end
+    #   _flex_slots =
+    #     for plyr <- plyrs do
+    #       insert(:roster_position, fantasy_team: team, fantasy_player: plyr)
+    #     end
 
-      attrs = %{
-        fantasy_team_id: team.id,
-        fantasy_player_id: add.id,
-        order: 1
-      }
+    #   attrs = %{
+    #     fantasy_team_id: team.id,
+    #     fantasy_player_id: add.id,
+    #     order: 1
+    #   }
 
-      changeset = DraftQueue.changeset(%DraftQueue{}, attrs)
+    #   changeset = DraftQueue.changeset(%DraftQueue{}, attrs)
 
-      assert changeset.errors == [
-               fantasy_player_id: {"No flex position available for this player", []}
-             ]
-    end
+    #   assert changeset.errors == [
+    #            fantasy_player_id: {"No flex position available for this player", []}
+    #          ]
+    # end
 
     test "no error if unavailable when too many flex spots in use" do
       league = insert(:fantasy_league, max_flex_spots: 5)


### PR DESCRIPTION
* Remove draft queue validation for flex spots
* Causes an error when creating an inseason draft queue
* Temp solution to allow LLWS 2021 draft