### PR TITLE
Use sports league name for select filters

### DIFF
--- a/lib/ex338_web/views/input_helpers.ex
+++ b/lib/ex338_web/views/input_helpers.ex
@@ -18,9 +18,7 @@ defmodule Ex338Web.InputHelpers do
 
     input_opts = [
       class:
-        "mt-1 #{form_type(type)} block w-full py-2 px-3 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:shadow-outline-blue focus:border-blue-300 transition duration-150 ease-in-out sm:text-sm sm:leading-5 #{
-          input_class
-        }"
+        "mt-1 #{form_type(type)} block w-full py-2 px-3 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:shadow-outline-blue focus:border-blue-300 transition duration-150 ease-in-out sm:text-sm sm:leading-5 #{input_class}"
     ]
 
     input_opts = maybe_add_select_options(type, input_opts, opts)

--- a/lib/ex338_web/views/view_helpers.ex
+++ b/lib/ex338_web/views/view_helpers.ex
@@ -81,7 +81,7 @@ defmodule Ex338Web.ViewHelpers do
 
   def sports_abbrevs(players_collection) do
     players_collection
-    |> Enum.map(& &1.sports_league.abbrev)
+    |> Enum.map(&format_sport_select_from_player/1)
     |> Enum.uniq()
   end
 
@@ -150,5 +150,9 @@ defmodule Ex338Web.ViewHelpers do
       value: id,
       class: "fantasy-team-#{current_team.id}"
     ]
+  end
+
+  defp format_sport_select_from_player(player) do
+    [key: player.sports_league.league_name, value: player.sports_league.abbrev]
   end
 end

--- a/test/ex338_web/views/view_helpers_test.exs
+++ b/test/ex338_web/views/view_helpers_test.exs
@@ -309,28 +309,32 @@ defmodule Ex338Web.ViewHelpersViewTest do
         %FantasyPlayer{
           id: 124,
           player_name: "Notre Dame",
-          sports_league: %SportsLeague{abbrev: "CBB"}
+          sports_league: %SportsLeague{league_name: "College Basketball", abbrev: "CBB"}
         },
         %FantasyPlayer{
           id: 127,
           player_name: "Ohio State",
-          sports_league: %SportsLeague{abbrev: "CBB"}
+          sports_league: %SportsLeague{league_name: "College Basketball", abbrev: "CBB"}
         },
         %FantasyPlayer{
           id: 128,
           player_name: "Ohio State",
-          sports_league: %SportsLeague{abbrev: "CFB"}
+          sports_league: %SportsLeague{league_name: "College Football", abbrev: "CFB"}
         },
         %FantasyPlayer{
           id: 129,
           player_name: "Boston U",
-          sports_league: %SportsLeague{abbrev: "CHK"}
+          sports_league: %SportsLeague{league_name: "College Hockey", abbrev: "CHK"}
         }
       ]
 
       result = ViewHelpers.sports_abbrevs(players)
 
-      assert result == ~w(CBB CFB CHK)
+      assert result == [
+               [key: "College Basketball", value: "CBB"],
+               [key: "College Football", value: "CFB"],
+               [key: "College Hockey", value: "CHK"]
+             ]
     end
   end
 end


### PR DESCRIPTION
* Use sports league name for select filters instead of abbrevs
* Easier for new people to understand
* No issues with space in the drop down window
* Closes #1092