### PR TITLE
Use sports league name for draft filter select

### DIFF
--- a/lib/ex338_web/live/draft_pick_live.ex
+++ b/lib/ex338_web/live/draft_pick_live.ex
@@ -168,13 +168,13 @@ defmodule Ex338Web.DraftPickLive do
       draft_picks
       |> Enum.reduce([], fn
         %{fantasy_player: %{sports_league: sports_league}}, options ->
-          [{sports_league.abbrev, sports_league.id}] ++ options
+          [{sports_league.league_name, sports_league.id}] ++ options
 
         _, options ->
           options
       end)
       |> Enum.uniq()
-      |> Enum.sort_by(fn {abbrev, _} -> abbrev end)
+      |> Enum.sort_by(fn {league_name, _} -> league_name end)
 
     [{"All Sports", ""}] ++ options
   end


### PR DESCRIPTION
* Use sports league name for draft filter select
* Easier for new people to grasp
* No issues with space in the select field
* See #1092