### PR TITLE
Add error tag to draft queue player in team update

### DIFF
--- a/lib/ex338_web/templates/fantasy_team/form_draft_queue.html.eex
+++ b/lib/ex338_web/templates/fantasy_team/form_draft_queue.html.eex
@@ -38,6 +38,7 @@
                 </td>
                 <td class="px-2 sm:px-6 py-2 whitespace-normal border-b border-gray-200 text-sm text-left leading-5 text-gray-500">
                   <%= q.data.fantasy_player.player_name %>
+                  <%= error_tag q, :fantasy_player_id %>
                 </td>
                 <td class="px-2 sm:px-6 py-2 whitespace-normal border-b border-gray-200 text-sm text-left leading-5 text-gray-500">
                   <%= q.data.fantasy_player.sports_league.abbrev %>


### PR DESCRIPTION
* Add error tag to draft queue player in team update
* Without error tag, flash would instruct to see errors below
* But no error was shown if it was associated with the player