### PR TITLE
Redirect heroku domain to canonical domain

### DIFF
--- a/lib/ex338_web/endpoint.ex
+++ b/lib/ex338_web/endpoint.ex
@@ -7,6 +7,8 @@ defmodule Ex338Web.Endpoint do
     signing_salt: "k6OGtovU"
   ]
 
+  plug(Ex338Web.CanonicalDomain)
+
   socket("/socket", Ex338Web.UserSocket, websocket: true, longpoll: false)
   socket("/live", Phoenix.LiveView.Socket, websocket: [connect_info: [session: @session_options]])
 

--- a/lib/ex338_web/plugs/canonical_domain.ex
+++ b/lib/ex338_web/plugs/canonical_domain.ex
@@ -1,0 +1,40 @@
+defmodule Ex338Web.CanonicalDomain do
+  @moduledoc """
+  Redirects to root domain when host is heroku domain.
+  """
+
+  import Plug.Conn
+
+  def init(options) do
+    # initialize options
+
+    options
+  end
+
+  def call(conn, _opts) do
+    uri =
+      conn
+      |> request_url()
+      |> URI.parse()
+
+    if redirect?(uri) do
+      uri = %{uri | host: canonical_host()}
+      canonical_url = URI.to_string(uri)
+
+      conn
+      |> put_status(:moved_permanently)
+      |> Phoenix.Controller.redirect(external: canonical_url)
+      |> halt()
+    else
+      conn
+    end
+  end
+
+  defp redirect?(%{host: "the338challenge.herokuapp.com"}), do: true
+
+  defp redirect?(_), do: false
+
+  defp canonical_host() do
+    Ex338Web.Endpoint.config(:url)[:host]
+  end
+end

--- a/test/ex338_web/plugs/canonical_domain_test.exs
+++ b/test/ex338_web/plugs/canonical_domain_test.exs
@@ -1,0 +1,16 @@
+defmodule Ex338Web.CanonicalDomainTest do
+  use Ex338Web.ConnCase
+  use Plug.Test
+
+  alias Ex338Web.{CanonicalDomain}
+
+  @opts CanonicalDomain.init([])
+
+  test "redirects to root domain when host is heroku domain" do
+    conn = conn(:get, "https://the338challenge.herokuapp.com/foo?bar=10")
+
+    conn = CanonicalDomain.call(conn, @opts)
+
+    assert redirected_to(conn, 301) =~ "https://localhost/foo?bar=10"
+  end
+end


### PR DESCRIPTION
* Previously used heroku domain but now using custom url
* Not possible to redirect heroku to root using DNS
* Redirects to the root domain if someone still using heroku domain
* Closes #1100