### PR TITLE
Fix phoenix liveview javascript error

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -13,7 +13,7 @@ import "alpinejs"
 import "phoenix_html"
 import { Socket } from "phoenix"
 import NProgress from "nprogress"
-import LiveSocket from "phoenix_live_view"
+import { LiveSocket } from "phoenix_live_view"
 
 // LiveView polyfills for IE11
 import "mdn-polyfills/NodeList.prototype.forEach"


### PR DESCRIPTION
Fix the following error:

```
Uncaught TypeError: phoenix_live_view__WEBPACK_IMPORTED_MODULE_5__.default is not a constructor
```