### PR TITLE
Send email to bcc & batch recipients

### DIFF
--- a/lib/ex338_web/controllers/commish_email_controller.ex
+++ b/lib/ex338_web/controllers/commish_email_controller.ex
@@ -22,7 +22,7 @@ defmodule Ex338Web.CommishEmailController do
         |> put_flash(:info, "Email sent successfully")
         |> redirect(to: Routes.commish_email_path(conn, :new))
 
-      {:error, {_code, reason}} ->
+      {:error, reason} ->
         conn
         |> put_flash(:error, "Email failed to send: #{reason}")
         |> redirect(to: Routes.commish_email_path(conn, :new))

--- a/lib/ex338_web/emails/commish_email.ex
+++ b/lib/ex338_web/emails/commish_email.ex
@@ -7,21 +7,44 @@ defmodule Ex338Web.CommishEmail do
     owners = FantasyTeams.get_leagues_email_addresses(leagues)
     admins = Repo.all(User.admin_emails())
     recipients = unique_recipients(owners, admins)
+    default_admin = Mailer.default_from_name_and_email()
 
     email_info = %{
-      to: recipients,
-      cc: [],
-      from: Mailer.default_from_name_and_email(),
+      cc: default_admin,
+      from: default_admin,
       subject: subject,
       message: message
     }
 
-    email_info
-    |> EmailTemplate.plain_text()
-    |> Mailer.deliver()
+    recipients
+    |> batch_by_aws_max_recipients()
+    |> Enum.map(fn recipients ->
+      email_info
+      |> Map.put(:bcc, recipients)
+      |> EmailTemplate.plain_text()
+      |> Mailer.deliver()
+      |> Mailer.handle_delivery()
+    end)
+    |> parse_results()
   end
 
   def unique_recipients(owners, admins) do
     Enum.uniq(owners ++ admins)
+  end
+
+  defp batch_by_aws_max_recipients(recipients) do
+    Enum.chunk_every(recipients, 40)
+  end
+
+  defp parse_results(results) do
+    Enum.reduce_while(results, {:ok, "commish emails sent"}, &parse_result/2)
+  end
+
+  defp parse_result({:ok, _result}, success_message) do
+    {:cont, success_message}
+  end
+
+  defp parse_result({:error, _message} = error, _success_message) do
+    {:halt, error}
   end
 end

--- a/lib/ex338_web/emails/email_template.ex
+++ b/lib/ex338_web/emails/email_template.ex
@@ -3,18 +3,12 @@ defmodule Ex338Web.EmailTemplate do
 
   import Swoosh.Email
 
-  def plain_text(%{
-        to: recipients,
-        cc: cc,
-        from: from,
-        subject: subject,
-        message: message
-      }) do
+  def plain_text(data) do
     new()
-    |> to(recipients)
-    |> cc(cc)
-    |> from(from)
-    |> subject(subject)
-    |> text_body(message)
+    |> bcc(data.bcc)
+    |> cc(data.cc)
+    |> from(data.from)
+    |> subject(data.subject)
+    |> text_body(data.message)
   end
 end

--- a/test/ex338/commish_email_test.exs
+++ b/test/ex338/commish_email_test.exs
@@ -14,8 +14,8 @@ defmodule Ex338.CommishEmailTest do
       message = "Here is the latest info!"
 
       email_info = %{
-        to: [{other_user.name, other_user.email}, {admin_user.name, admin_user.email}],
-        cc: [],
+        bcc: [{other_user.name, other_user.email}, {admin_user.name, admin_user.email}],
+        cc: {"338 Commish", "commish@the338challenge.com"},
         from: {"338 Commish", "commish@the338challenge.com"},
         subject: subject,
         message: message

--- a/test/ex338_web/controllers/commish_email_controller_test.exs
+++ b/test/ex338_web/controllers/commish_email_controller_test.exs
@@ -39,8 +39,8 @@ defmodule Ex338Web.CommishEmailControllerTest do
       message = "Here is the latest info!"
 
       email_info = %{
-        to: [{other_user.name, other_user.email}],
-        cc: [],
+        bcc: [{other_user.name, other_user.email}],
+        cc: {"338 Commish", "commish@the338challenge.com"},
         from: {"338 Commish", "commish@the338challenge.com"},
         subject: subject,
         message: message


### PR DESCRIPTION
* bcc so users don't all have each other's email address (privacy)
* batch because aws limits recipients to 50
* Closes #1122