### PR TITLE
Change additional_terms column in trades from string to text

### DIFF
--- a/priv/repo/migrations/20250419232727_alter_trade_additional_terms_to_text.exs
+++ b/priv/repo/migrations/20250419232727_alter_trade_additional_terms_to_text.exs
@@ -1,0 +1,9 @@
+defmodule Ex338.Repo.Migrations.AlterTradeAdditionalTermsToText do
+  use Ecto.Migration
+
+  def change do
+    alter table(:trades) do
+      modify :additional_terms, :text, from: :string
+    end
+  end
+end


### PR DESCRIPTION
This PR changes the database column type for additional_terms in the trades table from string to text, while keeping the schema definition as a string type.