### PR TITLE
Add automatic drafted_at update for next keeper picks

### DIFF
--- a/lib/ex338/draft_picks/draft_pick.ex
+++ b/lib/ex338/draft_picks/draft_pick.ex
@@ -105,6 +105,14 @@ defmodule Ex338.DraftPicks.DraftPick do
     |> limit(^picks)
   end
 
+  def next_pick_after_position(query, league_id, draft_position) do
+    query
+    |> by_league(league_id)
+    |> ordered_by_position()
+    |> where([d], d.draft_position > ^draft_position)
+    |> limit(1)
+  end
+
   def ordered_by_position(query) do
     from(d in query, order_by: d.draft_position)
   end

--- a/test/ex338/draft_picks/admin_test.exs
+++ b/test/ex338/draft_picks/admin_test.exs
@@ -1,6 +1,8 @@
 defmodule Ex338.DraftPicks.AdminTest do
   use Ex338.DataCase, async: true
 
+  alias Ex338.DraftPicks.Admin
+
   describe "draft_player/1" do
     test "dry run draft_player ecto multi" do
       league = insert(:fantasy_league)
@@ -9,7 +11,115 @@ defmodule Ex338.DraftPicks.AdminTest do
       player = insert(:fantasy_player)
       params = %{"fantasy_player_id" => player.id}
 
-      multi = Ex338.DraftPicks.Admin.draft_player(draft_pick, params)
+      multi = Admin.draft_player(draft_pick, params)
+
+      assert [
+               {:draft_pick, {:update, _draft_pick_changeset, []}},
+               {:roster_position, {:insert, _roster_position_changeset, []}},
+               {:unavailable_draft_queues, {:update_all, _, [], returning: true}},
+               {:drafted_draft_queues, {:update_all, _, [], returning: true}}
+             ] = Ecto.Multi.to_list(multi)
+    end
+
+    test "updates next keeper pick drafted_at when next pick is a keeper with player" do
+      league = insert(:fantasy_league)
+      team1 = insert(:fantasy_team, fantasy_league: league)
+      team2 = insert(:fantasy_team, fantasy_league: league)
+
+      current_pick =
+        insert(:draft_pick,
+          fantasy_team: team1,
+          fantasy_league: league,
+          draft_position: 1.0
+        )
+
+      keeper_player = insert(:fantasy_player)
+
+      _next_pick =
+        insert(:draft_pick,
+          fantasy_team: team2,
+          fantasy_league: league,
+          draft_position: 2.0,
+          fantasy_player: keeper_player,
+          is_keeper: true,
+          drafted_at: nil
+        )
+
+      player = insert(:fantasy_player)
+      params = %{"fantasy_player_id" => player.id}
+
+      multi = Admin.draft_player(current_pick, params)
+
+      assert [
+               {:draft_pick, {:update, _draft_pick_changeset, []}},
+               {:roster_position, {:insert, _roster_position_changeset, []}},
+               {:unavailable_draft_queues, {:update_all, _, [], returning: true}},
+               {:drafted_draft_queues, {:update_all, _, [], returning: true}},
+               {:next_keeper_drafted_at, {:update, _next_pick_changeset, []}}
+             ] = Ecto.Multi.to_list(multi)
+    end
+
+    test "does not update next pick when it is not a keeper" do
+      league = insert(:fantasy_league)
+      team1 = insert(:fantasy_team, fantasy_league: league)
+      team2 = insert(:fantasy_team, fantasy_league: league)
+
+      current_pick =
+        insert(:draft_pick,
+          fantasy_team: team1,
+          fantasy_league: league,
+          draft_position: 1.0
+        )
+
+      regular_player = insert(:fantasy_player)
+
+      _next_pick =
+        insert(:draft_pick,
+          fantasy_team: team2,
+          fantasy_league: league,
+          draft_position: 2.0,
+          fantasy_player: regular_player,
+          is_keeper: false
+        )
+
+      player = insert(:fantasy_player)
+      params = %{"fantasy_player_id" => player.id}
+
+      multi = Admin.draft_player(current_pick, params)
+
+      assert [
+               {:draft_pick, {:update, _draft_pick_changeset, []}},
+               {:roster_position, {:insert, _roster_position_changeset, []}},
+               {:unavailable_draft_queues, {:update_all, _, [], returning: true}},
+               {:drafted_draft_queues, {:update_all, _, [], returning: true}}
+             ] = Ecto.Multi.to_list(multi)
+    end
+
+    test "does not update next pick when it has no player assigned" do
+      league = insert(:fantasy_league)
+      team1 = insert(:fantasy_team, fantasy_league: league)
+      team2 = insert(:fantasy_team, fantasy_league: league)
+
+      current_pick =
+        insert(:draft_pick,
+          fantasy_team: team1,
+          fantasy_league: league,
+          draft_position: 1.0
+        )
+
+      _next_pick =
+        insert(:draft_pick,
+          fantasy_team: team2,
+          fantasy_league: league,
+          draft_position: 2.0,
+          fantasy_player: nil,
+          is_keeper: true
+        )
+
+      player = insert(:fantasy_player)
+      params = %{"fantasy_player_id" => player.id}
+
+      multi = Admin.draft_player(current_pick, params)
 
       assert [
                {:draft_pick, {:update, _draft_pick_changeset, []}},

--- a/test/ex338/draft_picks_test.exs
+++ b/test/ex338/draft_picks_test.exs
@@ -167,6 +167,39 @@ defmodule Ex338.DraftPicksTest do
       assert unavailable_queue.status == :unavailable
     end
 
+    test "updates next keeper pick drafted_at when next pick is a keeper with player" do
+      league = insert(:fantasy_league)
+      team1 = insert(:fantasy_team, fantasy_league: league)
+      team2 = insert(:fantasy_team, fantasy_league: league)
+
+      current_pick =
+        insert(:draft_pick,
+          fantasy_team: team1,
+          fantasy_league: league,
+          draft_position: 1.0
+        )
+
+      keeper_player = insert(:fantasy_player)
+
+      next_pick =
+        insert(:draft_pick,
+          fantasy_team: team2,
+          fantasy_league: league,
+          draft_position: 2.0,
+          fantasy_player: keeper_player,
+          is_keeper: true,
+          drafted_at: nil
+        )
+
+      player = insert(:fantasy_player)
+      params = %{"fantasy_player_id" => player.id}
+
+      {:ok, _result} = DraftPicks.draft_player(current_pick, params)
+
+      updated_next_pick = Repo.get(Ex338.DraftPicks.DraftPick, next_pick.id)
+      assert updated_next_pick.drafted_at != nil
+    end
+
     test "does not update draft pick and returns error with invalid params" do
       league = insert(:fantasy_league)
       team = insert(:fantasy_team, fantasy_league: league)


### PR DESCRIPTION
## Summary
- Automatically updates `drafted_at` timestamp when the next pick is a keeper with an assigned player
- Adds new multi-step function to draft_player workflow that checks next pick by draft position
- Only updates when next pick has both `fantasy_player_id` and `is_keeper: true`

## Changes
- Added `maybe_update_next_keeper_drafted_at/2` step to `draft_player/2` multi in `admin.ex`
- Created `next_pick_after_position/3` query function in `DraftPick` module following existing patterns
- Added comprehensive tests covering keeper vs non-keeper scenarios and integration test

## Test plan
- [x] Multi structure tests verify step is added only when conditions met
- [x] Integration test confirms `drafted_at` field actually gets updated
- [x] Edge cases tested (no player assigned, not a keeper, no next pick)
- [x] All existing tests continue to pass