### PR TITLE
Add draft grades and analysis display to draft picks page

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -1,10 +1,11 @@
 /* This file is for your main application css. */
 
-@import 'tailwindcss';
+@import "tailwindcss";
 
-@import 'nprogress/nprogress.css' layer(utilities);
+@import "nprogress/nprogress.css" layer(utilities);
+@import "trix/dist/trix.css";
 
-@import './live_view.css' layer(utilities);
+@import "./live_view.css" layer(utilities);
 
 @config '../tailwind.config.js';
 
@@ -28,4 +29,12 @@
 
 [x-cloak] {
   display: none;
+}
+
+.trix-button-group--file-tools {
+  display: none !important;
+}
+
+.trix-button--icon-attach {
+  display: none !important;
 }

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -14,6 +14,7 @@ import "phoenix_html"
 import { Socket } from "phoenix"
 import NProgress from "nprogress"
 import { LiveSocket } from "phoenix_live_view"
+import Trix from "trix"
 
 // LiveView polyfills for IE11
 import "mdn-polyfills/NodeList.prototype.forEach"

--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -10,6 +10,7 @@
         "formdata-polyfill": "^3.0.18",
         "mdn-polyfills": "^5.17.0",
         "nprogress": "^0.2.0",
+        "trix": "^2.1.15",
         "url-search-params-polyfill": "^8.1.0",
         "vega": "^5.33.0",
         "vega-embed": "^6.26.0",
@@ -211,6 +212,13 @@
       "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.4.tgz",
       "integrity": "sha512-MHmwBtCb7OCv1DSivz2UNJXPGU/1btAWRKlqJ2saEhVJkpkvqHMMaOpKg0v4sAbDWSQekHGvPVMM8nQ+Jen03Q==",
       "license": "MIT"
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/alpinejs": {
       "version": "2.8.2",
@@ -771,6 +779,15 @@
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
       "dev": true,
       "peer": true
+    },
+    "node_modules/dompurify": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.6.tgz",
+      "integrity": "sha512-/2GogDQlohXPZe6D6NOgQvXLPSYBqIWMnZ8zzOhn09REE4eyAzb+Hed3jhoM9OkuaJ8P6ZGTTVWQKAi8ieIzfQ==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
     },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
@@ -1955,6 +1972,15 @@
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "license": "MIT"
+    },
+    "node_modules/trix": {
+      "version": "2.1.15",
+      "resolved": "https://registry.npmjs.org/trix/-/trix-2.1.15.tgz",
+      "integrity": "sha512-LoaXWczdTUV8+3Box92B9b1iaDVbxD14dYemZRxi3PwY+AuDm97BUJV2aHLBUFPuDABhxp0wzcbf0CxHCVmXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "dompurify": "^3.2.5"
+      }
     },
     "node_modules/ts-interface-checker": {
       "version": "0.1.13",

--- a/assets/package.json
+++ b/assets/package.json
@@ -9,6 +9,7 @@
     "formdata-polyfill": "^3.0.18",
     "mdn-polyfills": "^5.17.0",
     "nprogress": "^0.2.0",
+    "trix": "^2.1.15",
     "url-search-params-polyfill": "^8.1.0",
     "vega": "^5.33.0",
     "vega-embed": "^6.26.0",

--- a/lib/ex338/fantasy_leagues.ex
+++ b/lib/ex338/fantasy_leagues.ex
@@ -19,6 +19,10 @@ defmodule Ex338.FantasyLeagues do
     FantasyLeague.changeset(fantasy_league, attrs)
   end
 
+  def change_league_as_commish(%FantasyLeague{} = fantasy_league, attrs \\ %{}) do
+    FantasyLeague.commish_changeset(fantasy_league, attrs)
+  end
+
   def create_draft_chat_for_championship(
         %FantasyLeague{} = fantasy_league,
         %Championship{} = championship
@@ -64,6 +68,14 @@ defmodule Ex338.FantasyLeagues do
   end
 
   def get_fantasy_league!(id), do: Repo.get!(FantasyLeague, id)
+
+  def get_fantasy_league_with_teams!(id) do
+    teams_query = from(t in Ex338.FantasyTeams.FantasyTeam, order_by: t.team_name)
+
+    FantasyLeague
+    |> Repo.get!(id)
+    |> Repo.preload(fantasy_teams: teams_query)
+  end
 
   def get_leagues_by_status(status) do
     Enum.map(list_leagues_by_status(status), &load_team_standings_data/1)
@@ -124,6 +136,12 @@ defmodule Ex338.FantasyLeagues do
   def update_fantasy_league(%FantasyLeague{} = fantasy_league, attrs) do
     fantasy_league
     |> FantasyLeague.changeset(attrs)
+    |> Repo.update()
+  end
+
+  def update_league_as_commish(%FantasyLeague{} = fantasy_league, attrs) do
+    fantasy_league
+    |> FantasyLeague.commish_changeset(attrs)
     |> Repo.update()
   end
 

--- a/lib/ex338/fantasy_leagues/fantasy_league.ex
+++ b/lib/ex338/fantasy_leagues/fantasy_league.ex
@@ -6,6 +6,8 @@ defmodule Ex338.FantasyLeagues.FantasyLeague do
   import Ecto.Changeset
   import Ecto.Query, warn: false
 
+  alias Ex338.FantasyTeams.FantasyTeam
+
   schema "fantasy_leagues" do
     field(:fantasy_league_name, :string)
     field(:year, :integer)
@@ -20,7 +22,7 @@ defmodule Ex338.FantasyLeagues.FantasyLeague do
     field(:max_flex_spots, :integer)
     field(:draft_picks_locked?, :boolean, default: false)
     belongs_to(:sport_draft, Ex338.FantasyPlayers.SportsLeague)
-    has_many(:fantasy_teams, Ex338.FantasyTeams.FantasyTeam)
+    has_many(:fantasy_teams, FantasyTeam)
     has_many(:draft_picks, Ex338.DraftPicks.DraftPick)
     has_many(:league_sports, Ex338.FantasyLeagues.LeagueSport)
 
@@ -52,6 +54,30 @@ defmodule Ex338.FantasyLeagues.FantasyLeague do
       :year
     ])
     |> validate_required([:fantasy_league_name, :year, :division])
+  end
+
+  @doc """
+  Builds a changeset for commish editing league with fantasy teams.
+  """
+  def commish_changeset(struct, params \\ %{}) do
+    struct
+    |> cast(params, [
+      :championships_end_at,
+      :championships_start_at,
+      :division,
+      :draft_method,
+      :draft_picks_locked?,
+      :fantasy_league_name,
+      :max_draft_hours,
+      :max_flex_spots,
+      :must_draft_each_sport?,
+      :navbar_display,
+      :only_flex?,
+      :sport_draft_id,
+      :year
+    ])
+    |> validate_required([:fantasy_league_name, :year, :division])
+    |> cast_assoc(:fantasy_teams, with: &FantasyTeam.commish_changeset/2)
   end
 
   def by_league(query, league_id) do

--- a/lib/ex338/fantasy_teams/fantasy_team.ex
+++ b/lib/ex338/fantasy_teams/fantasy_team.ex
@@ -31,6 +31,8 @@ defmodule Ex338.FantasyTeams.FantasyTeam do
     field(:total_draft_mins_adj, :integer, default: 0)
     field(:picks_selected, :integer, virtual: true, default: 0)
     field(:over_draft_time_limit?, :boolean, virtual: true, default: false)
+    field(:draft_grade, :string)
+    field(:draft_analysis, :string)
     belongs_to(:fantasy_league, Ex338.FantasyLeagues.FantasyLeague)
     has_many(:champ_with_events_results, Ex338.Championships.ChampWithEventsResult)
     has_many(:draft_picks, Ex338.DraftPicks.DraftPick)
@@ -95,6 +97,8 @@ defmodule Ex338.FantasyTeams.FantasyTeam do
     |> cast(params, [
       :autodraft_setting,
       :commish_notes,
+      :draft_analysis,
+      :draft_grade,
       :dues_paid,
       :fantasy_league_id,
       :max_flex_adj,
@@ -107,6 +111,13 @@ defmodule Ex338.FantasyTeams.FantasyTeam do
     |> validate_required([:team_name, :waiver_position])
     |> validate_length(:team_name, max: 16)
     |> foreign_key_constraint(:fantasy_league_id)
+  end
+
+  def commish_changeset(struct, params \\ %{}) do
+    struct
+    |> cast(params, [:team_name, :draft_grade, :draft_analysis])
+    |> validate_required([:team_name])
+    |> validate_length(:team_name, max: 16)
   end
 
   def count_pending_draft_queues(query, team_id) do

--- a/lib/ex338_web/live/commish/fantasy_league_live/edit.ex
+++ b/lib/ex338_web/live/commish/fantasy_league_live/edit.ex
@@ -29,7 +29,7 @@ defmodule Ex338Web.Commish.FantasyLeagueLive.Edit do
 
   @impl true
   def handle_params(%{"id" => id}, _, socket) do
-    fantasy_league = FantasyLeagues.get_fantasy_league!(id)
+    fantasy_league = FantasyLeagues.get_fantasy_league_with_teams!(id)
 
     socket =
       socket

--- a/lib/ex338_web/live/commish/fantasy_league_live/form_component.ex
+++ b/lib/ex338_web/live/commish/fantasy_league_live/form_component.ex
@@ -53,6 +53,39 @@ defmodule Ex338Web.Commish.FantasyLeagueLive.FormComponent do
         />
         <.input field={f[:max_draft_hours]} label="Max Draft Hours" type="number" />
         <.input field={f[:max_flex_spots]} label="Max Flex Spots" type="number" />
+
+        <div class="sm:col-span-full">
+          <h3 class="text-base font-medium text-gray-900 mb-4">Fantasy Teams</h3>
+          <div class="divide-y divide-gray-200">
+            <.inputs_for :let={team_form} field={f[:fantasy_teams]}>
+              <div class="py-6 first:pt-0">
+                <div class="space-y-4">
+                  <.input field={team_form[:team_name]} type="text" label="Team Name" readonly="true" />
+                  <.input
+                    field={team_form[:draft_grade]}
+                    type="text"
+                    label="Draft Grade"
+                    placeholder="A, B, C, D, F"
+                  />
+                  <div>
+                    <label class="block text-sm font-medium leading-6 text-gray-900">
+                      Draft Analysis
+                    </label>
+                    <.input
+                      field={team_form[:draft_analysis]}
+                      type="hidden"
+                      id={"trix-editor-#{team_form[:id].value}"}
+                    />
+                    <div id={"trix-editor-wrapper-#{team_form[:id].value}"} phx-update="ignore">
+                      <trix-editor input={"trix-editor-#{team_form[:id].value}"}></trix-editor>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </.inputs_for>
+          </div>
+        </div>
+
         <:actions>
           <.submit_buttons back_route={~p"/commish/fantasy_leagues/#{@fantasy_league}/approvals"} />
         </:actions>
@@ -63,7 +96,7 @@ defmodule Ex338Web.Commish.FantasyLeagueLive.FormComponent do
 
   @impl true
   def update(%{fantasy_league: fantasy_league} = assigns, socket) do
-    changeset = FantasyLeagues.change_fantasy_league(fantasy_league)
+    changeset = FantasyLeagues.change_league_as_commish(fantasy_league)
 
     socket =
       socket
@@ -79,7 +112,7 @@ defmodule Ex338Web.Commish.FantasyLeagueLive.FormComponent do
   def handle_event("validate", %{"fantasy_league" => fantasy_league_params}, socket) do
     changeset =
       socket.assigns.fantasy_league
-      |> FantasyLeagues.change_fantasy_league(fantasy_league_params)
+      |> FantasyLeagues.change_league_as_commish(fantasy_league_params)
       |> Map.put(:action, :validate)
 
     {:noreply, assign(socket, :changeset, changeset)}
@@ -90,7 +123,7 @@ defmodule Ex338Web.Commish.FantasyLeagueLive.FormComponent do
   end
 
   defp save_fantasy_league(socket, :edit, fantasy_league_params) do
-    case FantasyLeagues.update_fantasy_league(
+    case FantasyLeagues.update_league_as_commish(
            socket.assigns.fantasy_league,
            fantasy_league_params
          ) do

--- a/lib/ex338_web/live/draft_pick_live/index.ex
+++ b/lib/ex338_web/live/draft_pick_live/index.ex
@@ -188,6 +188,14 @@ defmodule Ex338Web.DraftPickLive.Index do
       current_user={@current_user}
       filtered_draft_picks={@filtered_draft_picks}
     />
+
+    <%= if all_teams_have_grades?(@fantasy_teams) or admin_grades_preview?(@fantasy_teams, @current_user) do %>
+      <.section_header>
+        Draft Grades & Analysis
+      </.section_header>
+
+      <.draft_grades_section fantasy_teams={@fantasy_teams} />
+    <% end %>
     """
   end
 
@@ -382,6 +390,23 @@ defmodule Ex338Web.DraftPickLive.Index do
         <% end %>
       </tbody>
     </.legacy_table>
+    """
+  end
+
+  defp draft_grades_section(assigns) do
+    ~H"""
+    <div class="lg:max-w-4xl space-y-6">
+      <%= for team <- Enum.sort_by(@fantasy_teams, & &1.team_name) do %>
+        <div class="bg-white shadow-sm border border-gray-200 rounded-lg p-4">
+          <h4 class="text-md font-semibold text-gray-900 mb-2">
+            <.fantasy_team_name_link fantasy_team={team} /> - Grade: {team.draft_grade}
+          </h4>
+          <div class="text-gray-700">
+            {raw(team.draft_analysis)}
+          </div>
+        </div>
+      <% end %>
+    </div>
     """
   end
 
@@ -829,5 +854,13 @@ defmodule Ex338Web.DraftPickLive.Index do
 
   def animate_in(element_id) do
     JS.add_class("animate-in slide-in-from-right duration-500", to: element_id)
+  end
+
+  defp all_teams_have_grades?(fantasy_teams) do
+    Enum.all?(fantasy_teams, & &1.draft_grade)
+  end
+
+  defp admin_grades_preview?(fantasy_teams, current_user) do
+    admin?(current_user) and Enum.any?(fantasy_teams, & &1.draft_grade)
   end
 end

--- a/priv/repo/migrations/20250802230356_add_draft_fields_to_fantasy_teams.exs
+++ b/priv/repo/migrations/20250802230356_add_draft_fields_to_fantasy_teams.exs
@@ -1,0 +1,10 @@
+defmodule Ex338.Repo.Migrations.AddDraftFieldsToFantasyTeams do
+  use Ecto.Migration
+
+  def change do
+    alter table(:fantasy_teams) do
+      add :draft_grade, :string
+      add :draft_analysis, :text
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Added draft_grade and draft_analysis fields to fantasy_teams schema
- Added commish interface to assign grades and analysis to teams
- Displays draft grades and analysis on draft picks page when all teams have grades
- Uses card layout for better readability of multi-paragraph analysis
- Adds rich text input with Trix