### PR TITLE
Add private fantasy leagues (hidden + authorized to members)

### DIFF
--- a/lib/ex338/fantasy_leagues.ex
+++ b/lib/ex338/fantasy_leagues.ex
@@ -3,6 +3,7 @@ defmodule Ex338.FantasyLeagues do
 
   import Ecto.Query
 
+  alias Ex338.Accounts.User
   alias Ex338.Championships
   alias Ex338.Championships.Championship
   alias Ex338.Chats
@@ -12,6 +13,7 @@ defmodule Ex338.FantasyLeagues do
   alias Ex338.FantasyLeagues.HistoricalRecord
   alias Ex338.FantasyLeagues.HistoricalWinning
   alias Ex338.FantasyTeams
+  alias Ex338.FantasyTeams.FantasyTeam
   alias Ex338.ICalendar.Event
   alias Ex338.Repo
 
@@ -77,9 +79,57 @@ defmodule Ex338.FantasyLeagues do
     |> Repo.preload(fantasy_teams: teams_query)
   end
 
-  def get_leagues_by_status(status) do
-    Enum.map(list_leagues_by_status(status), &load_team_standings_data/1)
+  def get_leagues_by_status(status, user \\ nil) do
+    status
+    |> list_leagues_by_status()
+    |> filter_visible_leagues(user)
+    |> Enum.map(&load_team_standings_data/1)
   end
+
+  @doc """
+  Returns true when the user is allowed to view the league. Public leagues are
+  visible to everyone, admins see everything, and private leagues are only
+  visible to users who own a team in them.
+  """
+  def can_access_league?(%FantasyLeague{private?: false}, _user), do: true
+  def can_access_league?(%FantasyLeague{}, %User{admin: true}), do: true
+
+  def can_access_league?(%FantasyLeague{id: league_id}, %User{id: user_id}),
+    do: league_member?(league_id, user_id)
+
+  def can_access_league?(%FantasyLeague{}, _user), do: false
+
+  def league_member?(league_id, user_id) do
+    FantasyTeam
+    |> FantasyTeam.by_league(league_id)
+    |> FantasyTeam.by_user(user_id)
+    |> Repo.exists?()
+  end
+
+  @doc """
+  Removes private leagues the user is not allowed to see. Admins keep all
+  leagues; other users keep public leagues plus any private league they own a
+  team in.
+  """
+  def filter_visible_leagues(leagues, %User{admin: true}), do: leagues
+
+  def filter_visible_leagues(leagues, user) do
+    member_ids = private_league_ids_for_user(user)
+    Enum.filter(leagues, &(not &1.private? or &1.id in member_ids))
+  end
+
+  defp private_league_ids_for_user(%User{id: user_id}) do
+    FantasyLeague
+    |> where(private?: true)
+    |> join(:inner, [l], t in FantasyTeam, on: t.fantasy_league_id == l.id)
+    |> join(:inner, [l, t], o in assoc(t, :owners))
+    |> where([l, t, o], o.user_id == ^user_id)
+    |> distinct(true)
+    |> select([l], l.id)
+    |> Repo.all()
+  end
+
+  defp private_league_ids_for_user(_user), do: []
 
   def list_all_winnings do
     HistoricalWinning
@@ -107,6 +157,7 @@ defmodule Ex338.FantasyLeagues do
     FantasyLeague
     |> FantasyLeague.leagues_by_status(status)
     |> FantasyLeague.sort_most_recent()
+    |> FantasyLeague.sort_private_first()
     |> FantasyLeague.sort_by_draft_method()
     |> FantasyLeague.sort_by_division()
     |> Repo.all()
@@ -115,6 +166,7 @@ defmodule Ex338.FantasyLeagues do
   def list_fantasy_leagues do
     FantasyLeague
     |> FantasyLeague.sort_most_recent()
+    |> FantasyLeague.sort_private_first()
     |> FantasyLeague.sort_by_draft_method()
     |> FantasyLeague.sort_by_division()
     |> Repo.all()

--- a/lib/ex338/fantasy_leagues/fantasy_league.ex
+++ b/lib/ex338/fantasy_leagues/fantasy_league.ex
@@ -21,6 +21,7 @@ defmodule Ex338.FantasyLeagues.FantasyLeague do
     field(:max_draft_hours, :integer, default: 0)
     field(:max_flex_spots, :integer)
     field(:draft_picks_locked?, :boolean, default: false)
+    field(:private?, :boolean, default: false)
     belongs_to(:sport_draft, Ex338.FantasyPlayers.SportsLeague)
     has_many(:fantasy_teams, FantasyTeam)
     has_many(:draft_picks, Ex338.DraftPicks.DraftPick)
@@ -50,6 +51,7 @@ defmodule Ex338.FantasyLeagues.FantasyLeague do
       :must_draft_each_sport?,
       :navbar_display,
       :only_flex?,
+      :private?,
       :sport_draft_id,
       :year
     ])
@@ -73,6 +75,7 @@ defmodule Ex338.FantasyLeagues.FantasyLeague do
       :must_draft_each_sport?,
       :navbar_display,
       :only_flex?,
+      :private?,
       :sport_draft_id,
       :year
     ])
@@ -94,5 +97,9 @@ defmodule Ex338.FantasyLeagues.FantasyLeague do
 
   def sort_most_recent(query) do
     from(t in query, order_by: [desc: t.year])
+  end
+
+  def sort_private_first(query) do
+    from(t in query, order_by: [desc: t.private?])
   end
 end

--- a/lib/ex338_web/components/layouts.ex
+++ b/lib/ex338_web/components/layouts.ex
@@ -9,6 +9,7 @@ defmodule Ex338Web.Layouts do
     |> filter_by_navbar(navbar)
     |> filter_by_draft_method(draft_method)
     |> sort_by_div()
+    |> sort_private_first()
     |> sort_by_year()
   end
 
@@ -134,6 +135,10 @@ defmodule Ex338Web.Layouts do
 
   defp sort_by_div(fantasy_leagues) do
     Enum.sort_by(fantasy_leagues, & &1.division)
+  end
+
+  defp sort_private_first(fantasy_leagues) do
+    Enum.sort_by(fantasy_leagues, & &1.private?, :desc)
   end
 
   defp sort_by_year(fantasy_leagues) do

--- a/lib/ex338_web/controllers/archived_league_controller.ex
+++ b/lib/ex338_web/controllers/archived_league_controller.ex
@@ -4,7 +4,7 @@ defmodule Ex338Web.ArchivedLeagueController do
   alias Ex338.FantasyLeagues
 
   def index(conn, _params) do
-    leagues = FantasyLeagues.get_leagues_by_status("archived")
+    leagues = FantasyLeagues.get_leagues_by_status("archived", conn.assigns.current_user)
 
     render(
       conn,

--- a/lib/ex338_web/controllers/page_controller.ex
+++ b/lib/ex338_web/controllers/page_controller.ex
@@ -5,7 +5,7 @@ defmodule Ex338Web.PageController do
   alias Ex338.Rulebooks
 
   def index(conn, _params) do
-    leagues = FantasyLeagues.get_leagues_by_status("primary")
+    leagues = FantasyLeagues.get_leagues_by_status("primary", conn.assigns.current_user)
     season_records = FantasyLeagues.list_current_season_records()
     all_time_records = FantasyLeagues.list_current_all_time_records()
     winnings = FantasyLeagues.list_all_winnings()

--- a/lib/ex338_web/live/commish/fantasy_league_live/form_component.ex
+++ b/lib/ex338_web/live/commish/fantasy_league_live/form_component.ex
@@ -31,6 +31,7 @@ defmodule Ex338Web.Commish.FantasyLeagueLive.FormComponent do
         <.input field={f[:division]} label="Division" type="text" />
         <.input field={f[:only_flex?]} label="Only Flex?" type="checkbox" />
         <.input field={f[:must_draft_each_sport?]} label="Must draft each sport?" type="checkbox" />
+        <.input field={f[:private?]} label="Private?" type="checkbox" />
         <.input
           field={f[:championships_start_at]}
           label="Championships Start At"

--- a/lib/ex338_web/live/fantasy_team_live/show.ex
+++ b/lib/ex338_web/live/fantasy_team_live/show.ex
@@ -4,6 +4,7 @@ defmodule Ex338Web.FantasyTeamLive.Show do
 
   import Ex338Web.FantasyTeamComponents
 
+  alias Ex338.FantasyLeagues
   alias Ex338.FantasyTeams
   alias Ex338.FantasyTeams.FantasyTeam
 
@@ -16,10 +17,20 @@ defmodule Ex338Web.FantasyTeamLive.Show do
   def handle_params(%{"id" => id}, _, socket) do
     case FantasyTeams.find(id) do
       %FantasyTeam{} = fantasy_team ->
-        {:noreply,
-         socket
-         |> assign(:fantasy_team, fantasy_team)
-         |> assign(:fantasy_league, fantasy_team.fantasy_league)}
+        if FantasyLeagues.can_access_league?(
+             fantasy_team.fantasy_league,
+             socket.assigns.current_user
+           ) do
+          {:noreply,
+           socket
+           |> assign(:fantasy_team, fantasy_team)
+           |> assign(:fantasy_league, fantasy_team.fantasy_league)}
+        else
+          {:noreply,
+           socket
+           |> put_flash(:error, "You don't have access to that league.")
+           |> push_navigate(to: ~p"/")}
+        end
 
       nil ->
         {:noreply,

--- a/lib/ex338_web/plugs/load_leagues.ex
+++ b/lib/ex338_web/plugs/load_leagues.ex
@@ -14,7 +14,12 @@ defmodule Ex338Web.LoadLeagues do
   end
 
   def call(conn, _opts) do
-    leagues = FantasyLeagues.list_fantasy_leagues()
+    leagues =
+      FantasyLeagues.filter_visible_leagues(
+        FantasyLeagues.list_fantasy_leagues(),
+        conn.assigns[:current_user]
+      )
+
     assign(conn, :leagues, leagues)
   end
 end

--- a/lib/ex338_web/plugs/require_league_access.ex
+++ b/lib/ex338_web/plugs/require_league_access.ex
@@ -1,0 +1,29 @@
+defmodule Ex338Web.Plugs.RequireLeagueAccess do
+  @moduledoc """
+  Blocks access to a fantasy league's pages when the current user is not allowed
+  to see it. Public leagues are open to everyone, admins see everything, and
+  private leagues are limited to users who own a team in them.
+  """
+  use Phoenix.VerifiedRoutes, endpoint: Ex338Web.Endpoint, router: Ex338Web.Router
+
+  import Phoenix.Controller
+  import Plug.Conn
+
+  alias Ex338.FantasyLeagues
+
+  def init(options), do: options
+
+  def call(conn, _opts) do
+    league_id = conn.params["fantasy_league_id"]
+    league = league_id && FantasyLeagues.get(league_id)
+
+    if league && FantasyLeagues.can_access_league?(league, conn.assigns[:current_user]) do
+      conn
+    else
+      conn
+      |> put_flash(:error, "You don't have access to that league.")
+      |> redirect(to: ~p"/")
+      |> halt()
+    end
+  end
+end

--- a/lib/ex338_web/router.ex
+++ b/lib/ex338_web/router.ex
@@ -30,6 +30,10 @@ defmodule Ex338Web.Router do
     plug(Ex338Web.LoadLeagues)
   end
 
+  pipeline :require_league_access do
+    plug(Ex338Web.Plugs.RequireLeagueAccess)
+  end
+
   pipeline :remove_root_layout do
     plug(:put_root_layout, false)
   end
@@ -88,6 +92,14 @@ defmodule Ex338Web.Router do
     live_session :leagues_current_user,
       on_mount: [{Ex338Web.UserAuth, :mount_current_user}] do
       live "/fantasy_teams/:id", FantasyTeamLive.Show, :show
+    end
+
+    live_session :leagues_require_access,
+      on_mount: [
+        {Ex338Web.UserAuth, :mount_current_user},
+        {Ex338Web.UserAuth, :require_league_access}
+      ] do
+      live "/fantasy_leagues/:id", FantasyLeagueLive.Show, :show
 
       scope "/fantasy_leagues/:fantasy_league_id" do
         live "/draft_picks", DraftPickLive.Index, :index
@@ -101,9 +113,9 @@ defmodule Ex338Web.Router do
       end
     end
 
-    live "/fantasy_leagues/:id", FantasyLeagueLive.Show, :show
-
     scope "/fantasy_leagues/:fantasy_league_id" do
+      pipe_through(:require_league_access)
+
       resources("/fantasy_teams", FantasyTeamController, only: [:index])
       resources("/fantasy_players", FantasyPlayerController, only: [:index])
       resources("/owners", OwnerController, only: [:index])
@@ -115,7 +127,12 @@ defmodule Ex338Web.Router do
 
     resources("/archived_leagues", ArchivedLeagueController, only: [:index])
 
-    get("/rules", PageController, :rules)
+    scope "/rules" do
+      pipe_through(:require_league_access)
+
+      get("/", PageController, :rules)
+    end
+
     get("/", PageController, :index)
   end
 

--- a/lib/ex338_web/user_auth.ex
+++ b/lib/ex338_web/user_auth.ex
@@ -6,6 +6,7 @@ defmodule Ex338Web.UserAuth do
   import Plug.Conn
 
   alias Ex338.Accounts
+  alias Ex338.FantasyLeagues
 
   # Make the remember me cookie valid for 60 days.
   # If you want bump or reduce this value, also change
@@ -172,6 +173,23 @@ defmodule Ex338Web.UserAuth do
       {:halt, Phoenix.LiveView.redirect(socket, to: signed_in_path(socket))}
     else
       {:cont, socket}
+    end
+  end
+
+  def on_mount(:require_league_access, params, session, socket) do
+    socket = mount_current_user(socket, session)
+    league_id = params["fantasy_league_id"] || params["id"]
+    league = league_id && FantasyLeagues.get(league_id)
+
+    if league && FantasyLeagues.can_access_league?(league, socket.assigns.current_user) do
+      {:cont, socket}
+    else
+      socket =
+        socket
+        |> Phoenix.LiveView.put_flash(:error, "You don't have access to that league.")
+        |> Phoenix.LiveView.redirect(to: ~p"/")
+
+      {:halt, socket}
     end
   end
 

--- a/priv/repo/migrations/20260720051438_add_private_to_fantasy_leagues.exs
+++ b/priv/repo/migrations/20260720051438_add_private_to_fantasy_leagues.exs
@@ -1,0 +1,9 @@
+defmodule Ex338.Repo.Migrations.AddPrivateToFantasyLeagues do
+  use Ecto.Migration
+
+  def change do
+    alter table(:fantasy_leagues) do
+      add :private?, :boolean, default: false, null: false
+    end
+  end
+end

--- a/test/ex338/fantasy_leagues_test.exs
+++ b/test/ex338/fantasy_leagues_test.exs
@@ -473,4 +473,59 @@ defmodule Ex338.FantasyLeaguesTest do
       assert result == nil
     end
   end
+
+  describe "can_access_league?/2" do
+    test "anyone can access a public league" do
+      league = insert(:fantasy_league, private?: false)
+
+      assert FantasyLeagues.can_access_league?(league, nil)
+      assert FantasyLeagues.can_access_league?(league, insert(:user))
+    end
+
+    test "admins can access a private league" do
+      league = insert(:fantasy_league, private?: true)
+      admin = insert(:user, admin: true)
+
+      assert FantasyLeagues.can_access_league?(league, admin)
+    end
+
+    test "members can access a private league they own a team in" do
+      league = insert(:fantasy_league, private?: true)
+      team = insert(:fantasy_team, fantasy_league: league)
+      user = insert(:user)
+      insert(:owner, fantasy_team: team, user: user)
+
+      assert FantasyLeagues.can_access_league?(league, user)
+    end
+
+    test "non-members and anonymous users cannot access a private league" do
+      league = insert(:fantasy_league, private?: true)
+
+      refute FantasyLeagues.can_access_league?(league, insert(:user))
+      refute FantasyLeagues.can_access_league?(league, nil)
+    end
+  end
+
+  describe "filter_visible_leagues/2" do
+    test "hides private leagues from non-members but keeps public ones" do
+      public = insert(:fantasy_league, private?: false)
+      private = insert(:fantasy_league, private?: true)
+      leagues = [public, private]
+
+      assert FantasyLeagues.filter_visible_leagues(leagues, insert(:user)) == [public]
+      assert FantasyLeagues.filter_visible_leagues(leagues, nil) == [public]
+    end
+
+    test "keeps private leagues for members and admins" do
+      public = insert(:fantasy_league, private?: false)
+      private = insert(:fantasy_league, private?: true)
+      team = insert(:fantasy_team, fantasy_league: private)
+      member = insert(:user)
+      insert(:owner, fantasy_team: team, user: member)
+      leagues = [public, private]
+
+      assert FantasyLeagues.filter_visible_leagues(leagues, member) == [public, private]
+      assert FantasyLeagues.filter_visible_leagues(leagues, insert(:user, admin: true)) == leagues
+    end
+  end
 end

--- a/test/ex338_web/controllers/fantasy_team_controller_test.exs
+++ b/test/ex338_web/controllers/fantasy_team_controller_test.exs
@@ -1,6 +1,31 @@
 defmodule Ex338Web.FantasyTeamControllerTest do
   use Ex338Web.ConnCase
 
+  describe "index/2 private league access" do
+    test "redirects a non-member away from a private league's pages", %{conn: conn} do
+      league = insert(:fantasy_league, private?: true)
+
+      conn = get(conn, ~p"/fantasy_leagues/#{league.id}/fantasy_teams")
+
+      assert redirected_to(conn) == ~p"/"
+      assert Phoenix.Flash.get(conn.assigns.flash, :error) =~ "don't have access"
+    end
+
+    test "allows a member to view a private league's pages", %{conn: conn} do
+      league = insert(:fantasy_league, private?: true)
+      team = insert(:fantasy_team, fantasy_league: league)
+      user = insert(:user)
+      insert(:owner, fantasy_team: team, user: user)
+
+      conn =
+        conn
+        |> log_in_user(user)
+        |> get(~p"/fantasy_leagues/#{league.id}/fantasy_teams")
+
+      assert html_response(conn, 200) =~ ~r/Fantasy Teams/
+    end
+  end
+
   describe "index/2" do
     test "lists all fantasy teams in a fantasy league", %{conn: conn} do
       league = insert(:fantasy_league)

--- a/test/ex338_web/controllers/page_controller_test.exs
+++ b/test/ex338_web/controllers/page_controller_test.exs
@@ -135,6 +135,29 @@ defmodule Ex338Web.PageControllerTest do
     assert html_response(conn, 200) =~ "338 Rules"
   end
 
+  test "GET /rules redirects a non-member away from a private league", %{conn: conn} do
+    league = insert(:fantasy_league, private?: true)
+
+    conn = get(conn, "/rules", %{"fantasy_league_id" => league.id})
+
+    assert redirected_to(conn) == ~p"/"
+    assert Phoenix.Flash.get(conn.assigns.flash, :error) =~ "don't have access"
+  end
+
+  test "GET /rules shows a private league's rules to a member", %{conn: conn} do
+    league = insert(:fantasy_league, private?: true, draft_method: "redraft")
+    team = insert(:fantasy_team, fantasy_league: league)
+    user = insert(:user)
+    insert(:owner, fantasy_team: team, user: user)
+
+    conn =
+      conn
+      |> log_in_user(user)
+      |> get("/rules", %{"fantasy_league_id" => league.id})
+
+    assert html_response(conn, 200) =~ "338 Rules"
+  end
+
   describe "GET /rules while logged in" do
     setup :register_and_log_in_user
 

--- a/test/ex338_web/live/fantasy_league_live/show_test.exs
+++ b/test/ex338_web/live/fantasy_league_live/show_test.exs
@@ -32,5 +32,37 @@ defmodule Ex338Web.FantasyLeagueLive.ShowTest do
       assert html =~ "16.0"
       assert html =~ "$70"
     end
+
+    test "redirects a non-member away from a private league", %{conn: conn} do
+      league = insert(:fantasy_league, private?: true)
+
+      assert {:error, {:redirect, %{to: "/", flash: %{"error" => msg}}}} =
+               live(conn, ~p"/fantasy_leagues/#{league.id}")
+
+      assert msg =~ "don't have access"
+    end
+
+    test "shows a private league to a member" do
+      league = insert(:fantasy_league, private?: true)
+      team = insert(:fantasy_team, team_name: "Brown", fantasy_league: league)
+      user = insert(:user)
+      insert(:owner, fantasy_team: team, user: user)
+      conn = log_in_user(build_conn(), user)
+
+      {:ok, _view, html} = live(conn, ~p"/fantasy_leagues/#{league.id}")
+
+      assert html =~ "Standings"
+      assert html =~ team.team_name
+    end
+
+    test "shows a private league to an admin", %{conn: conn} do
+      admin = insert(:user, admin: true)
+      league = insert(:fantasy_league, private?: true)
+      conn = log_in_user(conn, admin)
+
+      {:ok, _view, html} = live(conn, ~p"/fantasy_leagues/#{league.id}")
+
+      assert html =~ "Standings"
+    end
   end
 end

--- a/test/ex338_web/plugs/load_leagues_test.exs
+++ b/test/ex338_web/plugs/load_leagues_test.exs
@@ -13,4 +13,28 @@ defmodule Ex338Web.LoadLeaguesTest do
 
     assert conn.assigns.leagues == [league]
   end
+
+  test "hides private leagues from a non-member" do
+    public = insert(:fantasy_league, private?: false)
+    insert(:fantasy_league, private?: true)
+    conn = assign(build_conn(), :current_user, insert(:user))
+
+    conn = LoadLeagues.call(conn, @opts)
+
+    assert conn.assigns.leagues == [public]
+  end
+
+  test "keeps private leagues for a member" do
+    public = insert(:fantasy_league, private?: false)
+    private = insert(:fantasy_league, private?: true)
+    team = insert(:fantasy_team, fantasy_league: private)
+    member = insert(:user)
+    insert(:owner, fantasy_team: team, user: member)
+    conn = assign(build_conn(), :current_user, member)
+
+    conn = LoadLeagues.call(conn, @opts)
+
+    assert Enum.sort_by(conn.assigns.leagues, & &1.id) ==
+             Enum.sort_by([public, private], & &1.id)
+  end
 end


### PR DESCRIPTION
## Context

We're adding a private league to 338. It must be invisible to everyone except its members and admins, while members still see all the normal public leagues. Visibility is **authorized, not just hidden** — a non-member who knows the league URL is blocked, not just kept from seeing the link.

"Member of a league" = the user owns a `fantasy_team` in that league (via `owners`). Admins always see everything.

## What's included

- **Schema:** `private?` boolean (default `false`) on `fantasy_leagues`, added to both changesets, plus a `sort_private_first/1` query helper.
- **Authorization/filtering** (`Ex338.FantasyLeagues`): `can_access_league?/2` (public → everyone; admin → all; private → members only; anon/non-member → denied) and `filter_visible_leagues/2`.
- **Hidden from navbar/home:** `LoadLeagues` plug and the page/archived controllers filter by current user.
- **Ordering:** private leagues sort **above public ones of the same year, but below any newer-year league** (queries + navbar `Layouts.display`).
- **Auth on league pages (not just hidden):**
  - `Ex338Web.Plugs.RequireLeagueAccess` on the `/fantasy_leagues/:fantasy_league_id/*` controller routes.
  - `:require_league_access` `on_mount` hook on the league LiveViews (`Show`, draft picks, championships).
  - `/fantasy_teams/:id` split into its own live_session (its `:id` is a team, not a league) with an inline guard; team **edit** was already owner-gated.
- **Admin toggle:** a "Private?" checkbox in the commish league edit form.

Write mutations (create waiver/trade/IR, draft-pick edit) are keyed on a team/pick the acting user must already own, so they remain owner-gated and are out of scope here.

## Testing

- `mix compile --warnings-as-errors` clean, `mix format` clean.
- Migration applied to dev + test.
- Full suite: **925 tests, 0 failures.** New coverage for `can_access_league?/2`, `filter_visible_leagues/2`, navbar hiding, and controller + LiveView redirect/success for private leagues.

To create the private league after merge: edit it via `/commish/fantasy_leagues/:id/edit` and check "Private?". Members are whoever owns a team in it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019JegpcoCkUJwGUB672661w