### PR TITLE
Add 2027 rules for the standard league

### DIFF
--- a/priv/rules/2027_standard_rules.md
+++ b/priv/rules/2027_standard_rules.md
@@ -1,0 +1,249 @@
+%{
+year: 2027,
+draft_method: "redraft",
+}
+
+---
+
+**338 Rules for 2026-27 Season**
+
+**1. Season**
+
+The 2026-2027 338 Season includes sports with championships between August 1 2026 and July 31, 2027. There are 14 permanent sports and 2 sports that change each year.
+
+Permanent sports are: NCAA Football, NFL, NCAA Basketball, NBA, NCAA Hockey, NHL, NCAA Baseball, MLB, Champions League, Kentucky Derby, PGA, LLWS, Men's and Women's Tennis.
+
+In 2026-27, the rotating sports will be the Women's Soccer World Cup and F1 Racing. Subsequent years are to be determined but may include: Women's College Basketball, Rugby World Cup, Olympic Men's 3000m Steeplechase and Men's Soccer World Cup.
+
+**2. Ownership**
+
+Teams are allowed to have multiple owners and split the entry fee and winnings any way they choose.
+
+For league voting purposes, each team will only receive one vote, regardless of number of owners.
+
+Owners are not allowed to own or have partial ownership in multiple 338 teams in the same league, but may own or have partial ownership in teams in different leagues.
+
+If relegation/promotion puts 2 teams with the same owner or partial owner in the same league, owner(s) may drop ownership stake to a single team or else the lower ranked team(s) will be pushed down a league until all owners have a stake in only one team/league.
+
+**3. Rosters**
+
+Each Owner has 21 roster slots with one slot dedicated to each sport (16 slots) and 5 slots open to any sport. Roster slots may be left open at any time. All roster slots are eligible to earn league points (ie Flex Spots are active and not bench spots).
+
+**Tennis/Golf/F1**
+
+You do not have to use the same player throughout the year. 2 players used in the same event will require 2 roster slots, but waivering/trading players for each event is allowed and the scores will be combined. If using multiple roster slots, Owner must declare which slot a newly acquired player will be in (separate from roster slots). Owners cannot use the same player in multiple slots, unless 2 or more rostered players have been used in the same slot in different events. In that case, the owner may choose which slot both players go in. If a player is put on IR and replaced for an event, the injured player will still be considered to have occupied the slot for that event, not the replacement player.
+
+**Example Scenario**
+
+I have Tiger and Phil for The Masters, then trade them both for Rory and Scott prior to PGA. I must declare which players will be combined before the event. I choose #1-Tiger/Scott & #2-Phil/Rory. For the US Open, I trade Rory for Tiger and drop Scott for Stenson, making the combo #1-Tiger/Scott/Tiger & #2-Phil/Rory/Stenson. Then I claim Scott for British Open, keeping Tiger & Stenson. Stenson would remain in 2 but I could choose Tiger or Scott for slot 1 and the other would go in slot 3.
+
+**Injured Reserve**
+
+Each Owner will have one IR slot per individual sport (MT, WT, PGA, F1). If a player withdraws from an event prior to the start, Owner may move the player to IR and claim a new player, maintaining ownership of the injured player. This will not cost a waiver claim, but the replacement player will be automatically dropped at the end of the event.
+
+IR claims may be submitted at any time before the start of each event but are processed in the order submitted after the waiver deadline, giving priority to waiver claims. IR claims must be submitted prior to the start of the event.
+
+If a player is suspended for rules violation or does not qualify for an event, the player is not eligible for IR and must be replaced by a waiver claim.
+
+**4. Entry Fee**
+
+League A: $225, B: $250, C: $275, D: $300. Payment due at the start of the draft. Owners will not be allowed to begin drafting until payment is received. Entry fees and payouts only accepted from one user, regardless of the number of co-owners per team.
+
+**5. Scoring**
+
+Points are awarded to the top 8 of each sport. 8 points for winning the league, 5 points for runner-up, 3 points for reaching the semifinals, and 1 point for reaching the quarterfinals. See individual sport for details. If any team/player is later stripped of a standing, prior to relegation, due to violation of any kind, points will be adjusted. Any violation and resulting standings change post-relegation will have no impact on the 338.
+
+**Tennis**
+
+Tennis-only points are awarded for each of the 4 Grand Slam Events, immediately after the tournament. 1st=8, 2nd=5, SF=3, QF=1, R16=0.5. Negative 2 points awarded to a Top 8 Seed losing in the 1st round and Negative 1 point for a Top 8 Seed losing in the 2nd round. If match is a walkover or player retires before the completion of the first set, negative points will not apply. Tennis points will be tallied individually, to an assigned tennis slot, which are separate from Roster spots (e.g. Tennis-1, Tennis-2, etc). If a player is traded or dropped, the Owner retains any points they have earned as long as another player occupies that slot at the end of the season.
+
+**Example Scenario**
+
+I have Djokovic who wins the Aussie Open, scoring me 8 pts. I trade him for Nadal prior to the French Open. Nadal wins, so I now have 16 pts. If I had kept Djokovic and traded for Nadal prior to the French Open, then Nadal beats Djokovic, I would have 13 pts for my first Tennis slot (Djokovic Aussie W + FO 2nd place) and 8 pts for my second slot (Nadal FO W). League pts awarded to top 8 total scores.
+
+OWNER may have multiple places in the top 8 but must have a player in each roster slot qualifying for league points. Owner must score at least 1/2 point to be eligible
+
+**Golf**
+
+Golf-only points are awarded for each of the 4 majors, immediately after the tournament: 1st=50, 2nd=40, 3rd-36th=37,36,35…6,5,4 37th-40th =3, made cut =1, missed cut= -5. If a player is disqualified or withdraws in the 1st or 2nd round, it will be considered a missed cut. Golf points will be tallied to an assigned golf slot (e.g. PGA-1, PGA-2, etc). If a player is traded or dropped, the Owner retains any points they have earned.
+
+**Example Scenario**
+
+I have Tiger and Phil. Tiger wins the Masters (50pts) and Phil finishes 11th (29pts). I keep Tiger but drop Phil and Tiger wins the US Open. I now have 100pts for Tiger and still have 29pts for Phil. Prior to the British Open, I pick up Rory and still have Tiger. Rory wins and Tiger misses the cut. I now have 95 pts for Tiger and 79 pts combined for Phil/Rory. Following the four majors League points will be awarded to top 8 total scores. OWNER may have multiple places in the top 8 but must have a player in each roster slot qualifying for league points. Owner must score at least 1 point to be eligible
+
+**F1**
+
+F1 will include points from 4 races over the 2026-27 seasons: Italian GP and Brazilian GP in 2026 and Canadian GP and British GP in 2027. F1-only points awarded for the first 10 finishers at each Grand Prix, with 25 points for the winner, before scaling down to 18, 15, 12, 10, 8, 6, 4, 2, and a single point for the 10th-placed driver. Points will also be awarded for Sprints, if they are part of the 4 GP's, from eight down to one, awarded for the first eight cars to finish.
+
+**Tennis/Golf/F1 League Points**
+
+Players may be dropped and traded throughout the year, resulting in multiple players earning points. Rosters will lock after the final event's deadline and in order for league points to be earned, the scoring roster slot must be occupied by a player in that sport. If an owner finishes in the top 8 but does not have a player in the roster slot to earn those points, the slot will not count in the final standings and others will move up.
+
+**Example Scenario**
+
+If I have Djokovic and Nadal and they finish first and second in tennis, I must have 2 roster slots occupied by men's tennis players in order to earn league points. If I traded or dropped one of them and filled the roster slot with a different sport, I would only earn league points for the Tennis Slot the rostered player occupies. The 3rd place owner would then move up to 2nd, 4th to 3rd and so on.
+
+**Tie Breakers: Individual Sport**
+
+League points for Tennis and Golf will be split evenly among tied Owners at the end of the final major. Single event golf points awarded in full to each tied owner. Money split for 1st or 2nd place tie. League: Owners will split the winnings evenly. Relegation: See Below.
+
+**6. Payout** ***subject to change pending final owner count**
+
+**League A:**
+
+-   1st: $1240
+-   2nd: $950
+-   3rd: $700
+-   4th: $500
+-   5th: $350
+
+**League B:**
+
+-   1st: $1015
+-   2nd: $740
+-   3rd: $540
+-   4th: $405
+-   5th: $325
+
+**League C:**
+
+-   1st: $970
+-   2nd: $705
+-   3rd: $495
+-   4th: $395
+-   5th: $315
+
+**League D:**
+-   1st: $945
+-   2nd: $680
+-   3rd: $490
+-   4th: $390
+-   5th $310
+
+**Single Sport Payouts**
+
+1st: $25 2nd: $10. If an un-owned team finishes 1st or 2nd, money goes into league pot and divided equally among other money winners. If Owners tie in league standings, money is split evenly.
+
+**Payments**
+
+Payments will only be sent to one user, regardless of the number of owners per team.
+
+**7. Waiver Wire**
+
+Originally set by reverse draft order. A successful claim drops you to the bottom. All non-rostered players are on waivers. Waiver claims are made by submission via the site's Waivers Page. Select the player you want and hit submit. The league will be notified and there will be a 3-day waiting period where any other Owner may also claim the player.
+
+Claims process exactly 72 hours after the original claim (except at deadlines, see below), regardless of how many other owners put a claim in. At the 72-hour mark, the Owner with the highest waiver priority will be awarded the player and must roster the player.
+
+If no valid roster slots are available, the claim will process as invalid and go to the next Owner. If the Waiver deadline has already passed, a player in that sport may NOT be dropped, even if in the same sport as the player being claimed, unless claim/drop was entered prior to the deadline and processes after.
+
+Players to be dropped may be adjusted and claims may be canceled at any time during the wait period.
+
+**Waiting Periods**
+
+Waiting Period is waived near the deadline for College Hockey, Kentucky Derby, and LLWS. Due to the conference tournaments ending just before CHK bracket is announced, there will be no waiver period on claims. Instead, we will have a 1-week "quiet period" prior to the deadline. Claims will be announced to the league but players hidden and will process at the deadline based on waiver position. Claims submitted prior to the start of the quiet period will process in the standard 3 days.
+
+Extra draft picks at the end of KD & LLWS will be up for waiver claim until the individual draft begins. At that point, remaining draft picks and/or remaining players after the draft may be claimed with no waiting period.
+
+All waiver claims submitted within 48 hours of the deadline will process at 11:59 pm Pacific the day after the deadline.
+
+**Golf/Tennis/F1**
+
+Owners do NOT receive credit for points earned in tournaments prior to waiver pickup. Players may be dropped without a pick-up, leaving an open roster slot to be filled later. One roster slot must be dedicated to each sport and cannot be filled with a player from a different sport. Flex spots can be filled with players from any sport.
+
+**Waiver Deadline**
+
+See each sport for waiver deadlines. After the deadline NO players may be claimed or dropped from roster, except for late drops and pending claims in the waiting period.
+
+Any players that were dropped within 12 hours of deadline or dropped after a successful claim are eligible for claim for 24 hours after the deadline or drop time, whichever is later. This eliminates holding a player until the last minute to keep others from claiming. This also allows an Owner that put in a claim, but was trumped by a higher waiver to claim another player.
+
+**8. Trades**
+
+Trades of players and future round draft picks are allowed. Trades are submitted to another owner from the roster page. If the trade is accepted, the league will be notified. Trades are ineligible if they break any 338 rules stated herein or include any non-338 assets.
+
+There will be a 3-day voting period needing a majority Yes votes to pass. If an owner does not submit a vote during the voting period it will be considered an approval.
+
+Once a trade is submitted and the other owner accepts, the involved Owners are agreeing to the trade and may not make changes or vote against it unless all involved agree.
+
+Future Round Draft Picks may be traded, but only for the next draft to take place (if mid-draft, trades apply to that draft) and must be 1:1 (Owner-A trades 1st round pick to Owner-B for a player and 5th round pick.)
+
+Waiver position may be traded in the current season only.
+
+Only one condition or escalation may be included on each trade. If an escalation results in picks owed that have been included in multiple trades, the later trade will escalate to the next available pick.
+
+If an open roster slot is unavailable for a player being traded, the owner must add in the notes which player will be dropped to create roster space if the trade is approved. If no player is noted to be dropped, the trade will be declared invalid.
+
+**Golf/Tennis/F1**
+
+Points already earned by players that are traded stay with the former Owner.
+
+**Trade Deadline**
+
+See Championships page for deadlines. After the trade deadline NO players for that sport may be traded. If an owner submits a trade proposal on the site prior to the deadline, but the 2nd owner does not accept it until the following morning, the trade will be valid. If not accepted by Noon PT after the trade deadline, it will be invalid.
+
+**Future Round Draft Picks**
+
+Deadline for trading draft picks and players for future seasons is the trade deadline of the final sport
+
+**9. Draft**
+
+Draft order determined by random draw, with Owners placed in one bucket and draft position placed in a different bucket. The draft is conducted via website in Snake style. For leagues that have a smaller number of teams (e.g. KD, LLWS), every member must be able to draft a team from a league. Once the limit has been reached, only members without a team from that league will be allowed to draft from that sport. Once a draft pick has been emailed to the league, it cannot be changed.
+
+**Time Limit**
+
+Each Owner will have a cumulative total of 25 hours to make all 21 picks. There is no time limit for each pick. If an Owner exceeds 25 hours in total, the draft queue must be utilized to make picks. If the draft queue is empty, the Owner is able to manually enter a pick, but the site will proceed with the draft and allow the next Owner to enter their pick.
+
+Hours from 11pm - 6am local time will not count against draft time. If an owner is on the clock overnight, those hours will be deducted the following day by the commish. Default local time for each team is PST unless the team provides another time zone to the commish. Each team can identify one local time zone and cannot change it during the draft.
+
+**10. In-Season Drafts**
+
+Some sports will include a secondary draft in-season. During the main League Draft, you will select a draft position rather than a specific player (i.e. With my first round pick in the League draft, I select the First Pick of the Kentucky Derby). The following sports will have a secondary in-season draft:
+
+**Kentucky Derby**
+
+Draft will take place on race day, time TBD. There will be a 5 minute time limit per pick. After 5 minutes, if a pick is not in the draft queue and owner has not entered a pick they will be skipped. A skipped owner may pick at any time after that, but cannot take a horse already drafted. Draft limited to 18 horses so in the event of a late scratch Owner will be able to replace horse. If a horse is scratched after being drafted, a replacement may be picked at the completion of the draft and it will NOT count as a waiver claim. If multiple horses are scratched, replacements are chosen in original draft order.
+
+**LLWS**
+
+The draft for the LLWS will be Sunday August 11th. There will be a 5 minute time limit per pick. After 5 minutes, if a pick is not in the draft queue and owner has not entered a pick they will be skipped. A skipped owner may pick at any time after that, but cannot take a team already drafted. There are only 20 teams in the LLWS.
+
+11.  Relegation
+
+Based on League Points, the bottom 4 Owners in A,B and C will be relegated down a league. The top 4 Owners in B,C and D will move up one League.
+
+TIEBREAKERS (in order of application)
+
+LEAGUE: # of teams scoring league points, # of championships, lowest drafted team to score a league point (excludes waiver claims and trades).
+
+If relegation/promotion puts 2 teams with the same owner or partial owner in the same league, owner(s) may drop ownership stake to a single team or else the lower ranked team(s) will be pushed down a league until all owners have a stake in only one team/league. In this case, the last team relegated (i.e. 11th place of a 14-team league) will move back up
+
+DRAFT PICK TRADES: If relegation results in Owners that traded draft picks in different leagues, the traded picks will take place at the end of the round. EX: I trade my 1st round pick away and get a 10th round pick in return and I get relegated to B. The Owner I traded with would get my 1st round pick at the end of the 1st round. I would get the 10th round pick I traded for at the end of the 10th round. If both teams involved in the trade stay in the same league, or both get relegated, they would swap actual picks. If multiple Owners have supplemental picks, the order will be in reverse of the picks in that round.
+
+**12. Upper League Openings**
+
+New Owners will be placed in the lowest league of the new season, unless joining as a partial owner to an existing team. Exceptions may be granted at the discretion of the Board of Directors
+
+**13. Owner Departures**
+
+If an Owner finishes in the top 10 or is promoted but does not play the following season or an Owner is forced to drop a team or move down a league due to ownership of multiple teams, the last Owner relegated (i.e. 11th place) will move back up. This rule will apply until any openings are in the lowest league at which point a new owner will be added. Exceptions may be made at the discretion of the 338 Board of Directors.
+
+**14. Official Season**
+
+In order for the season to be official and payouts made, 8 sports must be completed or have the league name official results by July 20th, 2027. If 8 or more sports are canceled or delayed beyond July 20th, the 338 season will be canceled and all entry fees refunded with no winnings paid out. Trades of future draft picks will also be canceled.
+
+If a sport is canceled or delayed beyond July 20th 2027, no points will be awarded unless the league officially names a champion. All trades will be valid.
+
+In the event that a sport does not complete the season and the league declares an official champion but not a clear 2nd – 8th, the 338 will use the following rankings to award league points:
+
+-   MLB – 5 pts to best record in other league, 3 points to 2nd best record in each league and 1 pt to 3rd division leader and best record for a non-division leader. If the top 2 teams are in the same division, then 1 point to other 2 division leaders.
+-   CFB – AP Poll
+-   NFL – 5 pts to best record in other conference, 3 points to 2nd best record in each conference and 1 pt to 3rd & 4th best records in each conference.
+-   CBK – AP Poll
+-   NBA – 5 pts to best record in other conference, 3 points to 2nd best record in each conference and 1 pt to 3rd & 4th best records in each conference.
+-   CHK – Pairwise
+-   NHL – – 5 pts to best record in other conference, 3 points to 2nd best record in each conference and 1 pt to 3rd & 4th best records in each conference.
+-   NCAA Baseball – D1Baseball.com Rankings
+-   Champions League – points split among tied teams
+
+Exceptions: If a league has partially completed the postseason at the time of cancellation/suspension, actual results will be used.
+
+In order for PGA, MT and WT results to count in league play, at least 2 events must be completed by July 20th 2027.

--- a/test/ex338_web/controllers/page_controller_test.exs
+++ b/test/ex338_web/controllers/page_controller_test.exs
@@ -135,6 +135,14 @@ defmodule Ex338Web.PageControllerTest do
     assert html_response(conn, 200) =~ "338 Rules"
   end
 
+  test "GET /rules from 2027 without user", %{conn: conn} do
+    league = insert(:fantasy_league, year: 2027, draft_method: "redraft")
+
+    conn = get(conn, "/rules", %{"fantasy_league_id" => league.id})
+
+    assert html_response(conn, 200) =~ "338 Rules"
+  end
+
   test "GET /rules redirects a non-member away from a private league", %{conn: conn} do
     league = insert(:fantasy_league, private?: true)
 
@@ -253,6 +261,14 @@ defmodule Ex338Web.PageControllerTest do
 
     test "GET /keeper_rules from 2026", %{conn: conn} do
       league = insert(:fantasy_league, year: 2026, draft_method: "keeper")
+
+      conn = get(conn, "/rules", %{"fantasy_league_id" => league.id})
+
+      assert html_response(conn, 200) =~ "338 Rules"
+    end
+
+    test "GET /rules from 2027", %{conn: conn} do
+      league = insert(:fantasy_league, year: 2027, draft_method: "redraft")
 
       conn = get(conn, "/rules", %{"fantasy_league_id" => league.id})
 


### PR DESCRIPTION
Applies the tracked changes from the commissioner's "338 Rules for 2026-27" doc to a new 2027 standard rulebook, following the same pattern as 252db1a. Keeper rules are untouched here and will come from their own doc in a separate PR.

## Rule changes from the doc

- **Season** → 2026-27; 14 permanent + **2** rotating sports; rotating sports are **Women's Soccer World Cup and F1 Racing** (Men's World Cup moves to the future-years list)
- **Rosters** → **21 slots** (16 sport-dedicated + 5 flex); all slots are eligible to earn league points
- **F1 added throughout**: Tennis/Golf/F1 headings in rosters, waivers and trades, an F1 IR slot, and a new **F1 scoring section** — 4 races (Italian + Brazilian GP 2026, Canadian + British GP 2027), 25-18-15-12-10-8-6-4-2-1, sprint points 8→1
- "tournament" → "event" throughout the individual-sport rules
- **Entry fee** due **at the start of the draft** (was Oct 1st); no drafting until paid; late-payment disqualification sentence removed
- **Tennis**: R16=0.5 added; eligibility threshold now **1/2 point**
- **Payouts** lowered — A 1240/950/700/500/350 · B 1015/740/540/405/325 · C 970/705/495/395/315 · D 945/680/490/390/310
- Waiver waiting periods no longer mention Steeplechase or CBB (CHK only); waiver-deadline paragraph trimmed

## Judgment calls worth a look

1. **Official Season dates** — the doc still says "July 20th, **2026**" twice in section 14 (only the final line was tracked-changed to 2027). Since the season runs through July 31, 2027, both were updated to **2027**.
2. **Draft time limit** — the doc still said "all 20 picks"; updated to **21 picks** to match the new roster size. The 25-hour cumulative budget is unchanged.
3. **Golf scoring** in the doc's base text reads `3rd-36th=37,36,35…6,5,4 37th-40th =3`, which differs from the 2026 file (`3rd-35th…6,5,3 36th-40th`). Not a tracked change — pre-existing drift in the doc — the doc's version is used here.
4. Mechanical typo fixes only, no meaning changed: "allowed **to** begin drafting", "replaced for **an** event", "Golf will", "CHK bracket **is announced**", stray comma after "deadline for", and the missing `$` on League C 2nd ($705).
5. LLWS draft date still reads "Sunday August 11th" — stale, but untouched in the doc.

A 2027 `FantasyLeague` row with `draft_method: "redraft"` is still needed for this page to resolve.

## Test plan

- `mix test` — 1007 tests, 0 failures
- `mix format --check-formatted` — clean
- New tests cover `/rules` for a 2027 redraft league, logged out and logged in

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XLmJJPBt8zp6dpLVefTSCk