### PR TITLE
Show MCP setup instructions in the API tokens settings section

### DIFF
--- a/lib/ex338_web/live/user_settings_live.ex
+++ b/lib/ex338_web/live/user_settings_live.ex
@@ -139,6 +139,26 @@ defmodule Ex338Web.UserSettingsLive do
               </.button>
             </li>
           </ul>
+
+          <div class="mt-6 rounded-md bg-gray-100 p-4 text-sm">
+            <p class="font-semibold">Connect an MCP client</p>
+            <p class="mt-1 text-gray-600">
+              Point your MCP client at this endpoint and authenticate with a token above as a
+              bearer credential:
+            </p>
+            <code id="mcp_endpoint" class="mt-2 block break-all rounded bg-white p-2">
+              {@mcp_endpoint}
+            </code>
+            <p class="mt-3 text-gray-600">For Claude Code, run:</p>
+            <code class="mt-1 block break-all rounded bg-white p-2 text-xs">
+              claude mcp add --transport http the338 {@mcp_endpoint} --header "Authorization: Bearer YOUR_TOKEN"
+            </code>
+            <p class="mt-2 text-xs text-gray-500">
+              The <span class="font-mono font-semibold">Authorization</span>
+              header value must be exactly <span class="font-mono font-semibold">Bearer</span>
+              followed by a space and your token—a bare token is rejected.
+            </p>
+          </div>
         </div>
       </div>
     </.padded_container>
@@ -174,6 +194,7 @@ defmodule Ex338Web.UserSettingsLive do
       |> assign(:new_api_token, nil)
       |> assign(:api_tokens, Accounts.list_user_api_tokens(user))
       |> assign(:token_form, to_form(%{"name" => ""}, as: :token))
+      |> assign(:mcp_endpoint, url(~p"/api/v1/mcp"))
 
     {:ok, socket}
   end

--- a/test/ex338_web/live/user_settings_live_test.exs
+++ b/test/ex338_web/live/user_settings_live_test.exs
@@ -230,6 +230,15 @@ defmodule Ex338Web.UserSettingsLiveTest do
       assert stored.sent_to == "Claude MCP"
     end
 
+    test "shows MCP setup instructions with the endpoint", %{conn: conn} do
+      {:ok, _view, html} = live(conn, ~p"/users/settings")
+
+      assert html =~ "Connect an MCP client"
+      assert html =~ "/api/v1/mcp"
+      assert html =~ "claude mcp add"
+      assert html =~ "Bearer"
+    end
+
     test "lists existing tokens", %{conn: conn, user: user} do
       Accounts.create_user_api_token(user, "existing token")
 


### PR DESCRIPTION
Surfaces how to connect an MCP client right where users generate their tokens, including the `Bearer`-prefix requirement that's easy to miss.

## Changes
- **Account Settings → API Tokens** now shows:
  - The MCP endpoint URL, derived via `url(~p"/api/v1/mcp")` so it's correct in every environment (prod vs. dev).
  - The `claude mcp add` command for Claude Code, with the real endpoint interpolated (copy-paste, swap `YOUR_TOKEN`).
  - A note that the `Authorization` header must be `Bearer <token>` — a bare token is rejected (the exact snag we hit during setup).
- Test asserts the instructions and endpoint render.

## Testing
`mix test test/ex338_web/live/user_settings_live_test.exs` — 16 tests, 0 failures. `mix format --check-formatted` and `--warnings-as-errors` clean.

Scope is a single LiveView + its test; independent of other in-flight work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dz4SzQor4fTtCetL1dKTVY