### PR TITLE
Add draft pick writes to the API and MCP server

### DIFF
--- a/docs/api-and-mcp.md
+++ b/docs/api-and-mcp.md
@@ -72,9 +72,22 @@ Resources (each: shared `ApiActions` fn → REST endpoint + MCP tool, audited):
 - [x] Injured reserves — `POST …/injured_reserves` + `create_injured_reserve` tool
 - [x] Draft queues — `POST …/draft_queues` + `create_draft_queue` tool +
       `list_team_draft_queues` (owner/admin-scoped read, since a queue is private strategy)
+- [x] Draft picks — `POST /api/v1/draft_picks/:id/draft_player` + `draft_player` tool
+      (owner/admin, same rules as the draft page: pick must be up, flex spot, player
+      available; creates the roster position, updates queues, emails, starts autodraft),
+      `PATCH /api/v1/draft_picks/:id` + `update_draft_pick` tool (**admin only** —
+      corrects pick *metadata* only: order, owning team, keeper, drafted_at), and
+      `list_league_draft_picks` (the board, with `available_to_pick?`)
+- [x] Because the correction path writes only the `draft_picks` row,
+      `DraftPick.admin_changeset/2` holds the invariants that keeps it from corrupting
+      state the row is entangled with: the drafted player can't be changed or cleared
+      (its roster position isn't touched), the team can't be changed once the pick has
+      been used (same reason), the team must be non-null and in the pick's own league
+      (a null or foreign team breaks `DraftPicks.Clock` for the whole league), and the
+      league itself is not castable
 - [x] MCP read scoping: league reads via `FantasyLeagues.can_access_league?/2`
-      (`list_league_waivers`, `list_league_injured_reserves`); team reads via team ownership
-      (`list_team_draft_queues`)
+      (`list_league_waivers`, `list_league_injured_reserves`, `list_league_draft_picks`);
+      team reads via team ownership (`list_team_draft_queues`)
 - [ ] Trades — `Trades` create + votes (deferred: nested trade_line_items need a
       considered request shape for JSON/MCP)
 - [ ] Deletes / cancels (deferred): admins already authorized via Abilities; owner
@@ -86,7 +99,26 @@ still public and NOT league-scoped — a separate decision from the authenticate
 
 Current MCP tools: `whoami`, `list_league_waivers`, `create_waiver`,
 `list_league_injured_reserves`, `create_injured_reserve`, `list_team_draft_queues`,
-`create_draft_queue`.
+`create_draft_queue`, `list_league_draft_picks`, `draft_player`, `update_draft_pick`
+(admin only).
+
+Two shapes of write, worth keeping straight when adding more: **owner actions** run the
+domain rules everyone plays by (`draft_player` — your pick must be up), while
+**commissioner corrections** bypass them to fix the record (`update_draft_pick` — admin
+only, writes just the row). Don't collapse the two into one endpoint: an admin drafting
+normally should still go through the owner action so the roster position and draft queues
+are updated.
+
+A correction path that writes one row still owes the invariants of everything that row is
+joined to. Before exposing a raw-row update, ask what the row is entangled with (roster
+positions, the clock, unique indexes) and put those checks in an `admin_changeset` — a
+schema's plain `changeset/2` was written for trusted internal callers and usually has no
+FK constraints or null guards at all.
+
+Known gap: `draft_player` does not check the player against
+`FantasyPlayers.available_players/1` (that filter only ever existed as the HTML form's
+select options), so an API/MCP caller can draft an inactive or out-of-season player. The
+tool description says so explicitly rather than implying a check that isn't there.
 
 ### Phase 4 — MCP server ✅ done (hand-rolled JSON-RPC)
 Decision: hand-rolled, no new dependency. Stateless Streamable HTTP transport

--- a/lib/ex338/draft_picks.ex
+++ b/lib/ex338/draft_picks.ex
@@ -66,6 +66,41 @@ defmodule Ex338.DraftPicks do
     |> Repo.get!(id)
   end
 
+  @doc """
+  Fetches a draft pick with its assocs preloaded, or `nil` when it doesn't exist.
+
+  Unlike `get_draft_pick!/1` this tolerates ids that come from untrusted input
+  (an unparseable id is a miss, not an `Ecto.Query.CastError`), so API/MCP
+  callers can turn it into a not-found response.
+  """
+  def get_draft_pick(id) do
+    with {:ok, id} <- cast_id(id),
+         %DraftPick{} = draft_pick <- DraftPick |> DraftPick.preload_assocs() |> Repo.get(id) do
+      draft_pick
+    else
+      _ -> nil
+    end
+  end
+
+  @doc """
+  Corrects a draft pick's metadata — the commissioner path. The admin-only
+  authorization check lives in `Ex338Web.ApiActions`.
+
+  Writes only the pick row: no roster position is created and no draft queues are
+  updated, which is why `DraftPick.admin_changeset/2` accepts a narrower set of
+  fields than `changeset/2` (see its docs).
+
+  Deliberately does not broadcast. The `"draft_pick"` topic's events describe picks
+  being *made*, and `DraftPickLive.Index` renders the drafting team and player from
+  them — fields a corrected pick may not have. Open draft boards pick the change up
+  on their next periodic refresh instead.
+  """
+  def update_draft_pick(%DraftPick{} = draft_pick, params) do
+    draft_pick
+    |> DraftPick.admin_changeset(params)
+    |> Repo.update()
+  end
+
   def toggle_keeper(%DraftPick{} = draft_pick, is_keeper) do
     with {:ok, updated_draft_pick} <-
            draft_pick
@@ -121,6 +156,19 @@ defmodule Ex338.DraftPicks do
   end
 
   ## Helpers
+
+  ## get_draft_pick
+
+  defp cast_id(id) when is_integer(id), do: {:ok, id}
+
+  defp cast_id(id) when is_binary(id) do
+    case Integer.parse(id) do
+      {int, ""} -> {:ok, int}
+      _ -> :error
+    end
+  end
+
+  defp cast_id(_id), do: :error
 
   ## draft_player
 

--- a/lib/ex338/draft_picks/draft_pick.ex
+++ b/lib/ex338/draft_picks/draft_pick.ex
@@ -75,6 +75,24 @@ defmodule Ex338.DraftPicks.DraftPick do
     )
   end
 
+  @doc """
+  Builds a changeset for a commissioner correcting a pick's metadata.
+
+  Deliberately narrower than `changeset/2`, because this path writes only the pick
+  row: the league can't be reassigned (it would orphan the pick from the roster
+  positions and audit entries created under it), and neither can the player, since
+  the roster position created when the pick was used isn't updated here — changing
+  who was drafted has to go through `DraftPicks.draft_player/2`.
+  """
+  def admin_changeset(draft_pick, params \\ %{}) do
+    draft_pick
+    |> cast(params, [:draft_position, :drafted_at, :fantasy_team_id, :is_keeper])
+    |> validate_required([:draft_position, :fantasy_team_id])
+    |> validate_team_in_league()
+    |> validate_team_unchanged_once_used()
+    |> foreign_key_constraint(:fantasy_team_id)
+  end
+
   def picks_available_with_skips(draft_picks) do
     remaining_picks = remove_completed_picks(draft_picks)
 
@@ -121,14 +139,8 @@ defmodule Ex338.DraftPicks.DraftPick do
     draft_pick
     |> cast(params, [:fantasy_player_id])
     |> validate_required([:fantasy_player_id])
-    |> validate_pick_is_up()
-    |> validate_max_flex_spots()
-    |> validate_players_available_for_league()
-    |> add_drafted_at()
-    |> unique_constraint(:fantasy_player_id,
-      name: :draft_picks_fantasy_league_id_fantasy_player_id_index,
-      message: "Player already drafted in the league"
-    )
+    |> validate_player_exists()
+    |> validate_draft_rules()
   end
 
   def preload_assocs(query) do
@@ -225,7 +237,74 @@ defmodule Ex338.DraftPicks.DraftPick do
     |> Enum.any?(&(&1 == draft_pick_id))
   end
 
+  ## admin_changeset
+
+  # A pick belongs to one league; pointing it at a team from another would put a
+  # foreign team in this league's draft order and misfile the roster position that
+  # using the pick creates.
+  defp validate_team_in_league(changeset) do
+    case get_change(changeset, :fantasy_team_id) do
+      nil -> changeset
+      team_id -> do_validate_team_in_league(changeset, team_id)
+    end
+  end
+
+  defp do_validate_team_in_league(changeset, team_id) do
+    league_id = get_field(changeset, :fantasy_league_id)
+
+    case FantasyTeams.get_team_with_owners(team_id) do
+      nil ->
+        add_error(changeset, :fantasy_team_id, "does not exist")
+
+      %{fantasy_league_id: ^league_id} ->
+        changeset
+
+      _team_in_another_league ->
+        add_error(changeset, :fantasy_team_id, "must belong to the pick's league")
+    end
+  end
+
+  # The roster position a used pick created is tied to the drafting team, and this
+  # changeset doesn't touch roster positions.
+  defp validate_team_unchanged_once_used(changeset) do
+    if get_change(changeset, :fantasy_team_id) && changeset.data.fantasy_player_id do
+      add_error(changeset, :fantasy_team_id, "can't be changed once the pick has been used")
+    else
+      changeset
+    end
+  end
+
   ## owner_changeset
+
+  # The rules below load the drafted player and the league's whole board, so they
+  # can only run once the player id is known to resolve.
+  defp validate_draft_rules(%{valid?: false} = changeset), do: changeset
+
+  defp validate_draft_rules(changeset) do
+    changeset
+    |> validate_pick_is_up()
+    |> validate_max_flex_spots()
+    |> validate_players_available_for_league()
+    |> add_drafted_at()
+    |> unique_constraint(:fantasy_player_id,
+      name: :draft_picks_fantasy_league_id_fantasy_player_id_index,
+      message: "Player already drafted in the league"
+    )
+  end
+
+  defp validate_player_exists(changeset) do
+    case get_field(changeset, :fantasy_player_id) do
+      nil ->
+        changeset
+
+      player_id ->
+        if FantasyPlayers.player_with_sport!(FantasyPlayers.FantasyPlayer, player_id) do
+          changeset
+        else
+          add_error(changeset, :fantasy_player_id, "is invalid")
+        end
+    end
+  end
 
   defp add_drafted_at(changeset) do
     now = DateTime.truncate(DateTime.utc_now(), :second)

--- a/lib/ex338_web/api_actions.ex
+++ b/lib/ex338_web/api_actions.ex
@@ -8,14 +8,25 @@ defmodule Ex338Web.ApiActions do
   difference between an API call and an MCP call is the `source` string ("api" vs
   "mcp") the caller passes.
 
+  Most actions are owner-or-admin, mirroring what the HTML app allows. A few are
+  commissioner corrections that bypass the domain rules to fix the record
+  (`update_draft_pick/4`) and check `user.admin` directly.
+
   `actor` is `%{user: %Ex338.Accounts.User{}, api_token: %Ex338.Accounts.UserToken{} | nil}`.
   """
   alias Ex338.Audit
+  alias Ex338.AutoDraft
+  alias Ex338.DraftPicks
+  alias Ex338.DraftPicks.DraftPick
   alias Ex338.DraftQueues
   alias Ex338.FantasyTeams
   alias Ex338.FantasyTeams.FantasyTeam
   alias Ex338.InjuredReserves
   alias Ex338.Waivers
+
+  # Matches the HTML draft controller: give owners a moment to see their pick land
+  # before autodraft starts filling in queued picks behind them.
+  @autodraft_delay 1000 * 10
 
   @doc """
   Creates a waiver for a fantasy team. Returns `{:ok, %Waiver{}}`,
@@ -25,7 +36,7 @@ defmodule Ex338Web.ApiActions do
     team = FantasyTeams.get_team_with_owners(team_id)
     result = do_create_waiver(actor.user, team, params)
 
-    audit(actor, source, "waiver.create", "Waiver", result, team, %{
+    audit(actor, source, "waiver.create", "Waiver", result, league_id(team), %{
       fantasy_team_id: team_id,
       params: params
     })
@@ -66,7 +77,7 @@ defmodule Ex338Web.ApiActions do
     team = FantasyTeams.get_team_with_owners(team_id)
     result = do_create_injured_reserve(actor.user, team, params)
 
-    audit(actor, source, "injured_reserve.create", "InjuredReserve", result, team, %{
+    audit(actor, source, "injured_reserve.create", "InjuredReserve", result, league_id(team), %{
       fantasy_team_id: team_id,
       params: params
     })
@@ -101,7 +112,7 @@ defmodule Ex338Web.ApiActions do
     team = FantasyTeams.get_team_with_owners(team_id)
     result = do_create_draft_queue(actor.user, team, params)
 
-    audit(actor, source, "draft_queue.create", "DraftQueue", result, team, %{
+    audit(actor, source, "draft_queue.create", "DraftQueue", result, league_id(team), %{
       fantasy_team_id: team_id,
       params: params
     })
@@ -130,11 +141,137 @@ defmodule Ex338Web.ApiActions do
     |> Map.put("fantasy_team_id", team.id)
   end
 
-  defp audit(actor, source, action, resource_type, result, team, metadata) do
+  @doc """
+  Drafts a player with a draft pick — the same action an owner takes on the draft
+  page, with the same validations (your pick must be up, flex spots, player
+  availability), roster position, draft queue updates, email, and autodraft
+  follow-on. Owners may use their own team's picks; admins any pick.
+
+  Returns `{:ok, %DraftPick{}}`, `{:error, :not_found}`, `{:error, :forbidden}`,
+  `{:error, :draft_picks_locked}`, or `{:error, %Ecto.Changeset{}}`.
+  """
+  def draft_player(actor, source, draft_pick_id, params) do
+    draft_pick = DraftPicks.get_draft_pick(draft_pick_id)
+    result = do_draft_player(actor.user, draft_pick, params)
+
+    audit(actor, source, "draft_pick.draft_player", "DraftPick", result, league_id(draft_pick), %{
+      draft_pick_id: draft_pick_id,
+      params: params
+    })
+
+    result
+  end
+
+  defp do_draft_player(_user, nil, _params), do: {:error, :not_found}
+
+  defp do_draft_player(user, %DraftPick{} = draft_pick, params) do
+    cond do
+      not can_update?(user, draft_pick) -> {:error, :forbidden}
+      draft_pick.fantasy_league.draft_picks_locked? -> {:error, :draft_picks_locked}
+      is_nil(draft_pick.fantasy_team_id) -> {:error, missing_team_changeset(draft_pick)}
+      true -> submit_draft_pick(draft_pick, params)
+    end
+  end
+
+  # `fantasy_team_id` is nullable, and drafting needs a team to hold the roster
+  # position and to scope the draft-queue updates. Report it instead of letting the
+  # queue update raise on the missing team.
+  defp missing_team_changeset(draft_pick) do
+    draft_pick
+    |> Ecto.Changeset.change()
+    |> Ecto.Changeset.add_error(:fantasy_team_id, "can't be blank", validation: :required)
+    |> Map.put(:action, :update)
+  end
+
+  defp submit_draft_pick(draft_pick, params) do
+    case draft_player_params(params) do
+      %{"fantasy_player_id" => nil} -> {:error, blank_player_changeset(draft_pick)}
+      draft_player_params -> do_submit_draft_pick(draft_pick, draft_player_params)
+    end
+  end
+
+  # `DraftPicks.draft_player/2` builds its draft-queue updates from the player id,
+  # so it can't be handed a nil. Report the omission as the validation error the
+  # changeset would have produced.
+  defp blank_player_changeset(draft_pick) do
+    draft_pick
+    |> Ecto.Changeset.change()
+    |> Ecto.Changeset.add_error(:fantasy_player_id, "can't be blank", validation: :required)
+    |> Map.put(:action, :update)
+  end
+
+  defp do_submit_draft_pick(draft_pick, params) do
+    case DraftPicks.draft_player(draft_pick, params) do
+      {:ok, %{draft_pick: drafted_pick}} ->
+        Ex338Web.DraftPickNotifier.send_update(drafted_pick)
+        DraftQueues.reorder_for_league(drafted_pick.fantasy_league_id)
+
+        Task.start(fn ->
+          AutoDraft.make_picks_from_queues(drafted_pick, [], @autodraft_delay)
+        end)
+
+        {:ok, DraftPicks.get_draft_pick!(drafted_pick.id)}
+
+      {:error, _failed_operation, %Ecto.Changeset{} = changeset, _changes} ->
+        {:error, changeset}
+    end
+  end
+
+  # The player is the only thing a client picks. Everything else about the pick
+  # (which team, which league, when) comes from the pick being drafted with.
+  defp draft_player_params(params) do
+    %{"fantasy_player_id" => params["fantasy_player_id"]}
+  end
+
+  @doc """
+  Corrects a draft pick's metadata (order, owning team, keeper flag) — the
+  commissioner path, so it is admin-only.
+
+  Which fields may be corrected, and the invariants they have to hold, live in
+  `Ex338.DraftPicks.DraftPick.admin_changeset/2`; notably the drafted player is not
+  among them, because this path doesn't touch roster positions. Returns
+  `{:ok, %DraftPick{}}`, `{:error, :not_found}`, `{:error, :forbidden}`, or
+  `{:error, %Ecto.Changeset{}}`.
+  """
+  def update_draft_pick(actor, source, draft_pick_id, params) do
+    draft_pick = DraftPicks.get_draft_pick(draft_pick_id)
+    result = do_update_draft_pick(actor.user, draft_pick, params)
+
+    audit(actor, source, "draft_pick.update", "DraftPick", result, league_id(draft_pick), %{
+      draft_pick_id: draft_pick_id,
+      params: params
+    })
+
+    result
+  end
+
+  defp do_update_draft_pick(_user, nil, _params), do: {:error, :not_found}
+
+  defp do_update_draft_pick(%{admin: true}, %DraftPick{} = draft_pick, params) do
+    case DraftPicks.update_draft_pick(draft_pick, params) do
+      {:ok, updated_draft_pick} -> {:ok, DraftPicks.get_draft_pick!(updated_draft_pick.id)}
+      {:error, %Ecto.Changeset{}} = error -> error
+    end
+  end
+
+  defp do_update_draft_pick(_user, _draft_pick, _params), do: {:error, :forbidden}
+
+  # Admins pass via `Ex338.Abilities`; owners are checked against the pick's team,
+  # so a pick with no team assigned is admin-only.
+  defp can_update?(user, %DraftPick{fantasy_team: %FantasyTeam{}} = draft_pick) do
+    Canada.Can.can?(user, :update, draft_pick)
+  end
+
+  defp can_update?(user, %DraftPick{}), do: user.admin
+
+  defp league_id(%{fantasy_league_id: league_id}), do: league_id
+  defp league_id(_resource), do: nil
+
+  defp audit(actor, source, action, resource_type, result, fantasy_league_id, metadata) do
     Audit.log(%{
       user_id: actor.user.id,
       api_token_id: token_id(actor),
-      fantasy_league_id: team && team.fantasy_league_id,
+      fantasy_league_id: fantasy_league_id,
       source: source,
       action: action,
       resource_type: resource_type,

--- a/lib/ex338_web/controllers/api/v1/draft_pick_controller.ex
+++ b/lib/ex338_web/controllers/api/v1/draft_pick_controller.ex
@@ -2,9 +2,36 @@ defmodule Ex338Web.Api.V1.DraftPickController do
   use Ex338Web, :controller
 
   alias Ex338.DraftPicks
+  alias Ex338Web.ApiActions
+
+  action_fallback Ex338Web.Api.V1.FallbackController
 
   def index(conn, %{"fantasy_league_id" => league_id}) do
     %{draft_picks: draft_picks} = DraftPicks.get_picks_for_league(league_id)
     render(conn, :index, draft_picks: draft_picks)
+  end
+
+  @doc """
+  Drafts a player with this pick — owners on their own team's picks, admins on any.
+  """
+  def draft_player(conn, %{"id" => id, "draft_pick" => draft_pick_params}) do
+    with {:ok, draft_pick} <- ApiActions.draft_player(actor(conn), "api", id, draft_pick_params) do
+      render(conn, :show, draft_pick: draft_pick)
+    end
+  end
+
+  @doc """
+  Corrects a draft pick's fields directly (admin only). See
+  `Ex338Web.ApiActions.update_draft_pick/4` for what this does and does not touch.
+  """
+  def update(conn, %{"id" => id, "draft_pick" => draft_pick_params}) do
+    with {:ok, draft_pick} <-
+           ApiActions.update_draft_pick(actor(conn), "api", id, draft_pick_params) do
+      render(conn, :show, draft_pick: draft_pick)
+    end
+  end
+
+  defp actor(conn) do
+    %{user: conn.assigns.current_user, api_token: conn.assigns[:current_api_token]}
   end
 end

--- a/lib/ex338_web/controllers/api/v1/draft_pick_json.ex
+++ b/lib/ex338_web/controllers/api/v1/draft_pick_json.ex
@@ -3,20 +3,28 @@ defmodule Ex338Web.Api.V1.DraftPickJSON do
     %{draft_picks: Enum.map(draft_picks, &draft_pick_data/1)}
   end
 
+  # `pick_number` counts a pick's place among all of a league's picks, so it is only
+  # known when the whole board is loaded. Omitted rather than reported as null, so a
+  # client caching a write response can't overwrite a real pick number with nothing.
+  def show(%{draft_pick: draft_pick}) do
+    %{draft_pick: draft_pick |> draft_pick_data() |> Map.delete(:pick_number)}
+  end
+
   defp draft_pick_data(pick) do
     %{
       id: pick.id,
       draft_position: pick.draft_position,
       pick_number: pick.pick_number,
-      fantasy_team: %{
-        id: pick.fantasy_team.id,
-        team_name: pick.fantasy_team.team_name
-      },
+      fantasy_team: team_data(pick.fantasy_team),
       fantasy_player: player_data(pick.fantasy_player),
       drafted_at: pick.drafted_at,
       is_keeper: pick.is_keeper
     }
   end
+
+  defp team_data(%{id: id} = team), do: %{id: id, team_name: team.team_name}
+
+  defp team_data(_), do: nil
 
   defp player_data(%{id: id} = player) do
     %{

--- a/lib/ex338_web/controllers/api/v1/fallback_controller.ex
+++ b/lib/ex338_web/controllers/api/v1/fallback_controller.ex
@@ -24,6 +24,13 @@ defmodule Ex338Web.Api.V1.FallbackController do
     |> render(:error, message: "You are not authorized to perform this action")
   end
 
+  def call(conn, {:error, :draft_picks_locked}) do
+    conn
+    |> put_status(:unprocessable_entity)
+    |> put_view(json: ErrorJSON)
+    |> render(:error, message: "Draft picks are locked for this league")
+  end
+
   def call(conn, {:error, %Ecto.Changeset{} = changeset}) do
     conn
     |> put_status(:unprocessable_entity)

--- a/lib/ex338_web/controllers/api/v1/mcp/tools.ex
+++ b/lib/ex338_web/controllers/api/v1/mcp/tools.ex
@@ -4,12 +4,14 @@ defmodule Ex338Web.Api.V1.Mcp.Tools do
 
   Each tool is a thin wrapper over a context function. Write tools are authorized
   with the same `Ex338.Abilities` rules as the REST API (admins act on anything,
-  owners on their own teams) via `Ex338Web.ApiActions`; league read tools are
+  owners on their own teams) via `Ex338Web.ApiActions` — except commissioner-only
+  corrections like `update_draft_pick`, which require admin; league read tools are
   scoped by `FantasyLeagues.can_access_league?/2` so private leagues stay private.
   `call/3` receives the already-authenticated `actor` (established by
   `Ex338Web.Plugs.ApiAuth`) and returns a tagged result the MCP controller maps
   onto the JSON-RPC/tool-result envelope.
   """
+  alias Ex338.DraftPicks
   alias Ex338.DraftQueues
   alias Ex338.FantasyLeagues
   alias Ex338.FantasyTeams
@@ -113,6 +115,68 @@ defmodule Ex338Web.Api.V1.Mcp.Tools do
           required: ["fantasy_team_id", "fantasy_player_id"],
           additionalProperties: false
         }
+      },
+      %{
+        name: "list_league_draft_picks",
+        description:
+          "List the draft board for a fantasy league: every pick in order, who owns it, who " <>
+            "was drafted, and which picks are currently available to pick.",
+        inputSchema: %{
+          type: "object",
+          properties: %{
+            fantasy_league_id: %{type: "integer", description: "The fantasy league id"}
+          },
+          required: ["fantasy_league_id"],
+          additionalProperties: false
+        }
+      },
+      %{
+        name: "draft_player",
+        description:
+          "Draft a player with a draft pick. Runs the same rules as the draft page: the pick " <>
+            "must be up (or reachable by skipping teams over the clock), the team must have a " <>
+            "flex spot for the player, and the player must not already have been drafted in " <>
+            "this league. It does NOT verify the player is in the league's available pool, so " <>
+            "the caller is responsible for checking the player is active for this season and " <>
+            "not already owned. Also creates the roster position, updates draft queues, emails " <>
+            "the league, and starts autodraft. Owners may use their own team's picks; admins any pick.",
+        inputSchema: %{
+          type: "object",
+          properties: %{
+            draft_pick_id: %{type: "integer", description: "The draft pick to use"},
+            fantasy_player_id: %{type: "integer", description: "The player to draft"}
+          },
+          required: ["draft_pick_id", "fantasy_player_id"],
+          additionalProperties: false
+        }
+      },
+      %{
+        name: "update_draft_pick",
+        description:
+          "Admin only. Correct a draft pick's metadata, bypassing the draft rules — for fixing " <>
+            "the board (reassigning an unused pick, marking a keeper, adjusting the order). " <>
+            "Only the fields you pass are changed. This writes the pick alone and does not " <>
+            "touch roster positions or draft queues, which is why it cannot change who was " <>
+            "drafted (use draft_player for that) and cannot move a pick to another team once " <>
+            "the pick has been used. The owning team must be in the pick's own league.",
+        inputSchema: %{
+          type: "object",
+          properties: %{
+            draft_pick_id: %{type: "integer", description: "The draft pick to update"},
+            fantasy_team_id: %{
+              type: "integer",
+              description: "Team the pick belongs to; must be in the pick's league"
+            },
+            draft_position: %{type: "number", description: "Position in the draft order"},
+            is_keeper: %{type: "boolean", description: "Whether the pick is a keeper"},
+            drafted_at: %{
+              type: ["string", "null"],
+              description: "ISO 8601 timestamp the pick was made; null clears it"
+            }
+          },
+          required: ["draft_pick_id"],
+          additionalProperties: false
+        }
       }
     ]
   end
@@ -192,6 +256,39 @@ defmodule Ex338Web.Api.V1.Mcp.Tools do
     {:error, {:invalid_params, "fantasy_team_id is required"}}
   end
 
+  def call("list_league_draft_picks", %{"fantasy_league_id" => league_id}, %{user: user}) do
+    with_league_access(league_id, user, fn ->
+      %{draft_picks: draft_picks} = DraftPicks.get_picks_for_league(league_id)
+      {:ok, %{draft_picks: Enum.map(draft_picks, &board_pick_summary/1)}}
+    end)
+  end
+
+  def call("list_league_draft_picks", _args, _actor) do
+    {:error, {:invalid_params, "fantasy_league_id is required"}}
+  end
+
+  def call("draft_player", %{"draft_pick_id" => pick_id} = args, actor) do
+    case ApiActions.draft_player(actor, "mcp", pick_id, args) do
+      {:ok, draft_pick} -> {:ok, draft_pick_summary(draft_pick)}
+      error -> error
+    end
+  end
+
+  def call("draft_player", _args, _actor) do
+    {:error, {:invalid_params, "draft_pick_id is required"}}
+  end
+
+  def call("update_draft_pick", %{"draft_pick_id" => pick_id} = args, actor) do
+    case ApiActions.update_draft_pick(actor, "mcp", pick_id, args) do
+      {:ok, draft_pick} -> {:ok, draft_pick_summary(draft_pick)}
+      error -> error
+    end
+  end
+
+  def call("update_draft_pick", _args, _actor) do
+    {:error, {:invalid_params, "draft_pick_id is required"}}
+  end
+
   def call(_name, _args, _actor), do: {:error, :unknown_tool}
 
   # Scopes a league read to users who may see the league (public leagues, admins,
@@ -244,6 +341,34 @@ defmodule Ex338Web.Api.V1.Mcp.Tools do
       replacement_player_id: injured_reserve.replacement_player_id
     }
   end
+
+  defp draft_pick_summary(draft_pick) do
+    %{
+      id: draft_pick.id,
+      draft_position: draft_pick.draft_position,
+      fantasy_league_id: draft_pick.fantasy_league_id,
+      fantasy_team_id: draft_pick.fantasy_team_id,
+      team_name: assoc_field(draft_pick.fantasy_team, :team_name),
+      fantasy_player_id: draft_pick.fantasy_player_id,
+      player_name: assoc_field(draft_pick.fantasy_player, :player_name),
+      is_keeper: draft_pick.is_keeper,
+      drafted_at: draft_pick.drafted_at
+    }
+  end
+
+  # Adds the fields only the full board can answer — a pick's number and whether
+  # it can be used right now depend on every other pick in the league.
+  defp board_pick_summary(draft_pick) do
+    draft_pick
+    |> draft_pick_summary()
+    |> Map.merge(%{
+      pick_number: draft_pick.pick_number,
+      available_to_pick?: draft_pick.available_to_pick?
+    })
+  end
+
+  defp assoc_field(nil, _field), do: nil
+  defp assoc_field(assoc, field), do: Map.get(assoc, field)
 
   defp draft_queue_summary(draft_queue) do
     %{

--- a/lib/ex338_web/controllers/api/v1/mcp_controller.ex
+++ b/lib/ex338_web/controllers/api/v1/mcp_controller.ex
@@ -83,6 +83,10 @@ defmodule Ex338Web.Api.V1.McpController do
     {:ok, tool_error("You are not authorized to perform this action")}
   end
 
+  defp tool_result({:error, :draft_picks_locked}) do
+    {:ok, tool_error("Draft picks are locked for this league")}
+  end
+
   defp tool_result({:error, %Ecto.Changeset{} = changeset}) do
     %{errors: errors} = ErrorJSON.changeset_error(%{changeset: changeset})
     {:ok, tool_error("Validation failed: #{Jason.encode!(errors)}")}

--- a/lib/ex338_web/router.ex
+++ b/lib/ex338_web/router.ex
@@ -235,5 +235,10 @@ defmodule Ex338Web.Router do
       resources "/injured_reserves", InjuredReserveController, only: [:create]
       resources "/draft_queues", DraftQueueController, only: [:create]
     end
+
+    # Making a pick is an action any eligible owner can take; PATCHing the pick
+    # itself is the admin-only correction path.
+    post "/draft_picks/:id/draft_player", DraftPickController, :draft_player
+    resources "/draft_picks", DraftPickController, only: [:update]
   end
 end

--- a/test/ex338/draft_picks/draft_pick_test.exs
+++ b/test/ex338/draft_picks/draft_pick_test.exs
@@ -378,14 +378,18 @@ defmodule Ex338.DraftPicks.DraftPickTest do
   end
 
   @valid_attrs %{draft_position: "1.05", round: 42, fantasy_league_id: 1}
-  @valid_user_attrs %{
-    draft_position: "1.05",
-    round: 42,
-    fantasy_league_id: 1,
-    fantasy_team_id: 1,
-    fantasy_player_id: 1
-  }
   @invalid_attrs %{}
+
+  # The player has to exist — `owner_changeset/2` rejects an id that resolves to nothing.
+  defp valid_user_attrs do
+    %{
+      draft_position: "1.05",
+      round: 42,
+      fantasy_league_id: 1,
+      fantasy_team_id: 1,
+      fantasy_player_id: insert(:fantasy_player).id
+    }
+  end
 
   describe "changeset/2" do
     test "changeset with valid attributes" do
@@ -401,17 +405,17 @@ defmodule Ex338.DraftPicks.DraftPickTest do
 
   describe "owner_changeset/2" do
     test "with valid attributes" do
-      changeset = DraftPick.owner_changeset(%DraftPick{}, @valid_user_attrs)
+      changeset = DraftPick.owner_changeset(%DraftPick{}, valid_user_attrs())
       assert changeset.valid?
     end
 
     test "adds drafted_at when owner submits draft pick" do
-      changeset = DraftPick.owner_changeset(%DraftPick{}, @valid_user_attrs)
+      changeset = DraftPick.owner_changeset(%DraftPick{}, valid_user_attrs())
       refute changeset.changes.drafted_at == nil
     end
 
     test "only allows update to fantasy player" do
-      changeset = DraftPick.owner_changeset(%DraftPick{}, @valid_user_attrs)
+      changeset = DraftPick.owner_changeset(%DraftPick{}, valid_user_attrs())
       change_keys = changeset.changes |> Map.keys() |> MapSet.new()
 
       expected_change_keys = MapSet.new([:drafted_at, :fantasy_player_id])
@@ -421,6 +425,15 @@ defmodule Ex338.DraftPicks.DraftPickTest do
     test "with invalid attributes" do
       changeset = DraftPick.owner_changeset(%DraftPick{}, @valid_attrs)
       refute changeset.valid?
+    end
+
+    test "error when the player doesn't exist" do
+      attrs = %{valid_user_attrs() | fantasy_player_id: 0}
+
+      changeset = DraftPick.owner_changeset(%DraftPick{}, attrs)
+
+      refute changeset.valid?
+      assert "is invalid" in errors_on(changeset).fantasy_player_id
     end
 
     test "error when player already drafted in league" do

--- a/test/ex338/draft_picks_test.exs
+++ b/test/ex338/draft_picks_test.exs
@@ -295,6 +295,31 @@ defmodule Ex338.DraftPicksTest do
     end
   end
 
+  describe "update_draft_pick/2" do
+    test "updates the pick's fields" do
+      league = insert(:fantasy_league)
+      team = insert(:fantasy_team, fantasy_league: league)
+      pick = insert(:draft_pick, fantasy_league: league, fantasy_team: team, draft_position: 1.01)
+
+      {:ok, updated_pick} = DraftPicks.update_draft_pick(pick, %{"is_keeper" => true})
+
+      assert updated_pick.is_keeper == true
+    end
+
+    test "does not broadcast — the draft topic's events describe picks being made" do
+      league = insert(:fantasy_league)
+      team = insert(:fantasy_team, fantasy_league: league)
+      pick = insert(:draft_pick, fantasy_league: league, fantasy_team: team, draft_position: 1.01)
+      pick_id = pick.id
+      DraftPicks.subscribe()
+
+      {:ok, _updated_pick} = DraftPicks.update_draft_pick(pick, %{"is_keeper" => true})
+
+      # Scoped to this pick: the topic is global, so concurrent tests broadcast on it too.
+      refute_receive {"draft_pick", _event, %{id: ^pick_id}}
+    end
+  end
+
   describe "get_draft_pick!/1" do
     test "returns the draft pick for a given id" do
       draft_pick = insert(:draft_pick)

--- a/test/ex338_web/controllers/api/v1/draft_pick_controller_test.exs
+++ b/test/ex338_web/controllers/api/v1/draft_pick_controller_test.exs
@@ -1,6 +1,25 @@
 defmodule Ex338Web.Api.V1.DraftPickControllerTest do
   use Ex338Web.ConnCase
 
+  alias Ex338.Accounts
+  alias Ex338.Audit
+  alias Ex338.DraftPicks.DraftPick
+  alias Ex338.RosterPositions.RosterPosition
+
+  defp auth(conn, user) do
+    token = Accounts.create_user_api_token(user, "test")
+    put_req_header(conn, "authorization", "Bearer " <> token)
+  end
+
+  defp setup_draft_data(league_attrs \\ []) do
+    league = insert(:fantasy_league, league_attrs)
+    team = insert(:fantasy_team, fantasy_league: league)
+    player = insert(:fantasy_player)
+    pick = insert(:draft_pick, draft_position: 1.01, fantasy_team: team, fantasy_league: league)
+
+    %{league: league, team: team, player: player, pick: pick}
+  end
+
   describe "GET /api/v1/fantasy_leagues/:fantasy_league_id/draft_picks" do
     test "returns draft picks for a league", %{conn: conn} do
       league = insert(:fantasy_league)
@@ -23,6 +42,318 @@ defmodule Ex338Web.Api.V1.DraftPickControllerTest do
       assert pick["draft_position"]
       assert pick["fantasy_team"]["team_name"]
       assert pick["fantasy_player"]["player_name"]
+    end
+  end
+
+  describe "POST /api/v1/draft_picks/:id/draft_player" do
+    test "an owner can draft a player with their pick", %{conn: conn} do
+      %{team: team, player: player, pick: pick} = setup_draft_data()
+      user = insert(:user)
+      insert(:owner, fantasy_team: team, user: user)
+
+      conn =
+        conn
+        |> auth(user)
+        |> post(~p"/api/v1/draft_picks/#{pick.id}/draft_player",
+          draft_pick: %{fantasy_player_id: player.id}
+        )
+
+      assert %{"draft_pick" => data} = json_response(conn, 200)
+      assert data["fantasy_player"]["id"] == player.id
+      assert data["drafted_at"]
+      assert Repo.get!(DraftPick, pick.id).fantasy_player_id == player.id
+      assert Repo.get_by(RosterPosition, fantasy_team_id: team.id, fantasy_player_id: player.id)
+
+      assert [entry] = Audit.list_for_user(user.id)
+      assert entry.action == "draft_pick.draft_player"
+      assert entry.source == "api"
+      assert entry.outcome == "success"
+    end
+
+    test "an admin can draft with another team's pick", %{conn: conn} do
+      %{player: player, pick: pick} = setup_draft_data()
+      admin = insert(:user, admin: true)
+
+      conn =
+        conn
+        |> auth(admin)
+        |> post(~p"/api/v1/draft_picks/#{pick.id}/draft_player",
+          draft_pick: %{fantasy_player_id: player.id}
+        )
+
+      assert json_response(conn, 200)["draft_pick"]
+      assert Repo.get!(DraftPick, pick.id).fantasy_player_id == player.id
+    end
+
+    test "a non-owner is forbidden and the denial is logged", %{conn: conn} do
+      %{player: player, pick: pick} = setup_draft_data()
+      stranger = insert(:user)
+
+      conn =
+        conn
+        |> auth(stranger)
+        |> post(~p"/api/v1/draft_picks/#{pick.id}/draft_player",
+          draft_pick: %{fantasy_player_id: player.id}
+        )
+
+      assert json_response(conn, 403)["error"]
+      assert Repo.get!(DraftPick, pick.id).fantasy_player_id == nil
+
+      assert [entry] = Audit.list_for_user(stranger.id)
+      assert entry.outcome == "denied"
+    end
+
+    test "returns 422 when the league's draft picks are locked", %{conn: conn} do
+      %{team: team, player: player, pick: pick} = setup_draft_data(draft_picks_locked?: true)
+      user = insert(:user)
+      insert(:owner, fantasy_team: team, user: user)
+
+      conn =
+        conn
+        |> auth(user)
+        |> post(~p"/api/v1/draft_picks/#{pick.id}/draft_player",
+          draft_pick: %{fantasy_player_id: player.id}
+        )
+
+      assert json_response(conn, 422)["error"] =~ "locked"
+      assert Repo.get!(DraftPick, pick.id).fantasy_player_id == nil
+    end
+
+    test "returns 422 without a player", %{conn: conn} do
+      %{team: team, pick: pick} = setup_draft_data()
+      user = insert(:user)
+      insert(:owner, fantasy_team: team, user: user)
+
+      conn =
+        conn
+        |> auth(user)
+        |> post(~p"/api/v1/draft_picks/#{pick.id}/draft_player", draft_pick: %{})
+
+      assert json_response(conn, 422)["errors"]
+    end
+
+    test "returns 422 for a player that doesn't exist", %{conn: conn} do
+      %{team: team, pick: pick} = setup_draft_data()
+      user = insert(:user)
+      insert(:owner, fantasy_team: team, user: user)
+
+      conn =
+        conn
+        |> auth(user)
+        |> post(~p"/api/v1/draft_picks/#{pick.id}/draft_player",
+          draft_pick: %{fantasy_player_id: 999_999}
+        )
+
+      assert %{"errors" => %{"fantasy_player_id" => ["is invalid"]}} = json_response(conn, 422)
+      assert Repo.get!(DraftPick, pick.id).fantasy_player_id == nil
+    end
+
+    test "returns 422 for a pick with no team assigned", %{conn: conn} do
+      league = insert(:fantasy_league)
+      player = insert(:fantasy_player)
+
+      pick =
+        insert(:draft_pick, draft_position: 1.01, fantasy_league: league, fantasy_team: nil)
+
+      admin = insert(:user, admin: true)
+
+      conn =
+        conn
+        |> auth(admin)
+        |> post(~p"/api/v1/draft_picks/#{pick.id}/draft_player",
+          draft_pick: %{fantasy_player_id: player.id}
+        )
+
+      assert %{"errors" => %{"fantasy_team_id" => _}} = json_response(conn, 422)
+      assert Repo.get!(DraftPick, pick.id).fantasy_player_id == nil
+    end
+
+    test "returns 404 for a missing pick", %{conn: conn} do
+      user = insert(:user)
+
+      conn =
+        conn
+        |> auth(user)
+        |> post(~p"/api/v1/draft_picks/0/draft_player", draft_pick: %{fantasy_player_id: 1})
+
+      assert json_response(conn, 404)["error"]
+    end
+
+    test "returns 401 without a token", %{conn: conn} do
+      conn = post(conn, ~p"/api/v1/draft_picks/1/draft_player", draft_pick: %{})
+
+      assert json_response(conn, 401)["error"]
+    end
+  end
+
+  describe "PATCH /api/v1/draft_picks/:id" do
+    test "an admin can correct a pick's fields", %{conn: conn} do
+      %{league: league, pick: pick} = setup_draft_data()
+      other_team = insert(:fantasy_team, fantasy_league: league)
+      admin = insert(:user, admin: true)
+
+      conn =
+        conn
+        |> auth(admin)
+        |> patch(~p"/api/v1/draft_picks/#{pick.id}",
+          draft_pick: %{fantasy_team_id: other_team.id, is_keeper: true}
+        )
+
+      assert %{"draft_pick" => data} = json_response(conn, 200)
+      assert data["is_keeper"] == true
+      assert data["fantasy_team"]["id"] == other_team.id
+
+      updated_pick = Repo.get!(DraftPick, pick.id)
+      assert updated_pick.fantasy_team_id == other_team.id
+      assert updated_pick.is_keeper == true
+
+      assert [entry] = Audit.list_for_user(admin.id)
+      assert entry.action == "draft_pick.update"
+      assert entry.source == "api"
+    end
+
+    test "an owner cannot update their own pick's fields", %{conn: conn} do
+      %{team: team, pick: pick} = setup_draft_data()
+      user = insert(:user)
+      insert(:owner, fantasy_team: team, user: user)
+
+      conn =
+        conn
+        |> auth(user)
+        |> patch(~p"/api/v1/draft_picks/#{pick.id}", draft_pick: %{is_keeper: true})
+
+      assert json_response(conn, 403)["error"]
+      assert Repo.get!(DraftPick, pick.id).is_keeper == false
+
+      assert [entry] = Audit.list_for_user(user.id)
+      assert entry.outcome == "denied"
+    end
+
+    test "omits pick_number rather than reporting it as null", %{conn: conn} do
+      %{pick: pick} = setup_draft_data()
+      admin = insert(:user, admin: true)
+
+      conn =
+        conn
+        |> auth(admin)
+        |> patch(~p"/api/v1/draft_picks/#{pick.id}", draft_pick: %{is_keeper: true})
+
+      assert %{"draft_pick" => data} = json_response(conn, 200)
+      refute Map.has_key?(data, "pick_number")
+    end
+
+    test "the league cannot be reassigned", %{conn: conn} do
+      %{league: league, pick: pick} = setup_draft_data()
+      other_league = insert(:fantasy_league)
+      admin = insert(:user, admin: true)
+
+      conn =
+        conn
+        |> auth(admin)
+        |> patch(~p"/api/v1/draft_picks/#{pick.id}",
+          draft_pick: %{fantasy_league_id: other_league.id}
+        )
+
+      assert json_response(conn, 200)["draft_pick"]
+      assert Repo.get!(DraftPick, pick.id).fantasy_league_id == league.id
+    end
+
+    test "the drafted player cannot be changed or cleared", %{conn: conn} do
+      %{league: league, team: team, player: player} = setup_draft_data()
+
+      pick =
+        insert(:draft_pick,
+          draft_position: 1.01,
+          fantasy_league: league,
+          fantasy_team: team,
+          fantasy_player: player
+        )
+
+      admin = insert(:user, admin: true)
+
+      conn =
+        conn
+        |> auth(admin)
+        |> patch(~p"/api/v1/draft_picks/#{pick.id}", draft_pick: %{fantasy_player_id: nil})
+
+      assert json_response(conn, 200)["draft_pick"]
+      assert Repo.get!(DraftPick, pick.id).fantasy_player_id == player.id
+    end
+
+    test "returns 422 when the team is cleared", %{conn: conn} do
+      %{pick: pick} = setup_draft_data()
+      admin = insert(:user, admin: true)
+
+      conn =
+        conn
+        |> auth(admin)
+        |> patch(~p"/api/v1/draft_picks/#{pick.id}", draft_pick: %{fantasy_team_id: nil})
+
+      assert %{"errors" => %{"fantasy_team_id" => ["can't be blank"]}} = json_response(conn, 422)
+      refute is_nil(Repo.get!(DraftPick, pick.id).fantasy_team_id)
+    end
+
+    test "returns 422 for a team in another league", %{conn: conn} do
+      %{team: team, pick: pick} = setup_draft_data()
+      other_league_team = insert(:fantasy_team, fantasy_league: insert(:fantasy_league))
+      admin = insert(:user, admin: true)
+
+      conn =
+        conn
+        |> auth(admin)
+        |> patch(~p"/api/v1/draft_picks/#{pick.id}",
+          draft_pick: %{fantasy_team_id: other_league_team.id}
+        )
+
+      assert %{"errors" => %{"fantasy_team_id" => ["must belong to the pick's league"]}} =
+               json_response(conn, 422)
+
+      assert Repo.get!(DraftPick, pick.id).fantasy_team_id == team.id
+    end
+
+    test "returns 422 for a team that doesn't exist", %{conn: conn} do
+      %{team: team, pick: pick} = setup_draft_data()
+      admin = insert(:user, admin: true)
+
+      conn =
+        conn
+        |> auth(admin)
+        |> patch(~p"/api/v1/draft_picks/#{pick.id}", draft_pick: %{fantasy_team_id: 999_999})
+
+      assert %{"errors" => %{"fantasy_team_id" => ["does not exist"]}} = json_response(conn, 422)
+      assert Repo.get!(DraftPick, pick.id).fantasy_team_id == team.id
+    end
+
+    test "returns 422 when moving a pick that has already been used", %{conn: conn} do
+      %{league: league, team: team, player: player} = setup_draft_data()
+      other_team = insert(:fantasy_team, fantasy_league: league)
+
+      pick =
+        insert(:draft_pick,
+          draft_position: 1.01,
+          fantasy_league: league,
+          fantasy_team: team,
+          fantasy_player: player
+        )
+
+      admin = insert(:user, admin: true)
+
+      conn =
+        conn
+        |> auth(admin)
+        |> patch(~p"/api/v1/draft_picks/#{pick.id}",
+          draft_pick: %{fantasy_team_id: other_team.id}
+        )
+
+      assert %{"errors" => %{"fantasy_team_id" => [message]}} = json_response(conn, 422)
+      assert message =~ "once the pick has been used"
+      assert Repo.get!(DraftPick, pick.id).fantasy_team_id == team.id
+    end
+
+    test "returns 401 without a token", %{conn: conn} do
+      conn = patch(conn, ~p"/api/v1/draft_picks/1", draft_pick: %{})
+
+      assert json_response(conn, 401)["error"]
     end
   end
 end

--- a/test/ex338_web/controllers/api/v1/mcp_controller_test.exs
+++ b/test/ex338_web/controllers/api/v1/mcp_controller_test.exs
@@ -4,6 +4,9 @@ defmodule Ex338Web.Api.V1.McpControllerTest do
   alias Ex338.Accounts
   alias Ex338.Audit
   alias Ex338.CalendarAssistant
+  alias Ex338.DraftPicks.DraftPick
+  alias Ex338.DraftQueues.DraftQueue
+  alias Ex338.RosterPositions.RosterPosition
   alias Ex338.Waivers.Waiver
 
   defp rpc(conn, user, payload) do
@@ -41,6 +44,15 @@ defmodule Ex338Web.Api.V1.McpControllerTest do
     insert(:roster_position, fantasy_player: drop, fantasy_team: team)
 
     %{team: team, add: add, drop: drop}
+  end
+
+  defp setup_draft_data(league_attrs \\ []) do
+    league = insert(:fantasy_league, league_attrs)
+    team = insert(:fantasy_team, fantasy_league: league)
+    player = insert(:fantasy_player)
+    pick = insert(:draft_pick, draft_position: 1.01, fantasy_team: team, fantasy_league: league)
+
+    %{league: league, team: team, player: player, pick: pick}
   end
 
   describe "initialize / ping / method routing" do
@@ -92,6 +104,9 @@ defmodule Ex338Web.Api.V1.McpControllerTest do
       assert "whoami" in names
       assert "list_league_waivers" in names
       assert "create_waiver" in names
+      assert "list_league_draft_picks" in names
+      assert "draft_player" in names
+      assert "update_draft_pick" in names
       assert Enum.all?(tools, &is_map(&1["inputSchema"]))
     end
   end
@@ -275,6 +290,358 @@ defmodule Ex338Web.Api.V1.McpControllerTest do
                json_response(conn, 200)
 
       assert content["text"] =~ "not authorized"
+    end
+  end
+
+  describe "tools/call list_league_draft_picks" do
+    test "returns the draft board with which picks are available", %{conn: conn} do
+      %{league: league, team: team, pick: pick} = setup_draft_data()
+      user = insert(:user)
+
+      conn = call_tool(conn, user, "list_league_draft_picks", %{fantasy_league_id: league.id})
+
+      assert %{"result" => %{"isError" => false, "content" => [content]}} =
+               json_response(conn, 200)
+
+      assert %{"draft_picks" => [board_pick]} = Jason.decode!(content["text"])
+      assert board_pick["id"] == pick.id
+      assert board_pick["team_name"] == team.team_name
+      assert board_pick["pick_number"] == 1
+      assert board_pick["available_to_pick?"] == true
+      assert board_pick["fantasy_player_id"] == nil
+    end
+
+    test "a non-member cannot read a private league's board", %{conn: conn} do
+      %{league: league} = setup_draft_data(private?: true)
+      outsider = insert(:user)
+
+      conn = call_tool(conn, outsider, "list_league_draft_picks", %{fantasy_league_id: league.id})
+
+      assert %{"result" => %{"isError" => true, "content" => [content]}} =
+               json_response(conn, 200)
+
+      assert content["text"] =~ "not authorized"
+    end
+  end
+
+  describe "tools/call draft_player" do
+    test "an owner can draft a player with their pick", %{conn: conn} do
+      %{team: team, player: player, pick: pick} = setup_draft_data()
+      user = insert(:user)
+      insert(:owner, fantasy_team: team, user: user)
+      queue = insert(:draft_queue, fantasy_team: team, fantasy_player: player)
+
+      conn =
+        call_tool(conn, user, "draft_player", %{
+          draft_pick_id: pick.id,
+          fantasy_player_id: player.id
+        })
+
+      assert %{"result" => %{"isError" => false, "content" => [content]}} =
+               json_response(conn, 200)
+
+      assert Jason.decode!(content["text"])["player_name"] == player.player_name
+      assert Repo.get!(DraftPick, pick.id).fantasy_player_id == player.id
+      assert Repo.get_by(RosterPosition, fantasy_team_id: team.id, fantasy_player_id: player.id)
+      assert Repo.get!(DraftQueue, queue.id).status == :drafted
+
+      assert [entry] = Audit.list_for_user(user.id)
+      assert entry.source == "mcp"
+      assert entry.action == "draft_pick.draft_player"
+      assert entry.outcome == "success"
+      assert entry.resource_id == pick.id
+    end
+
+    test "an admin can draft with another team's pick", %{conn: conn} do
+      %{player: player, pick: pick} = setup_draft_data()
+      admin = insert(:user, admin: true)
+
+      conn =
+        call_tool(conn, admin, "draft_player", %{
+          draft_pick_id: pick.id,
+          fantasy_player_id: player.id
+        })
+
+      assert %{"result" => %{"isError" => false}} = json_response(conn, 200)
+      assert Repo.get!(DraftPick, pick.id).fantasy_player_id == player.id
+    end
+
+    test "a non-owner cannot draft with someone else's pick", %{conn: conn} do
+      %{player: player, pick: pick} = setup_draft_data()
+      stranger = insert(:user)
+
+      conn =
+        call_tool(conn, stranger, "draft_player", %{
+          draft_pick_id: pick.id,
+          fantasy_player_id: player.id
+        })
+
+      assert %{"result" => %{"isError" => true, "content" => [content]}} =
+               json_response(conn, 200)
+
+      assert content["text"] =~ "not authorized"
+      assert Repo.get!(DraftPick, pick.id).fantasy_player_id == nil
+
+      assert [entry] = Audit.list_for_user(stranger.id)
+      assert entry.outcome == "denied"
+    end
+
+    test "drafting is refused when the league's draft picks are locked", %{conn: conn} do
+      %{team: team, player: player, pick: pick} = setup_draft_data(draft_picks_locked?: true)
+      user = insert(:user)
+      insert(:owner, fantasy_team: team, user: user)
+
+      conn =
+        call_tool(conn, user, "draft_player", %{
+          draft_pick_id: pick.id,
+          fantasy_player_id: player.id
+        })
+
+      assert %{"result" => %{"isError" => true, "content" => [content]}} =
+               json_response(conn, 200)
+
+      assert content["text"] =~ "locked"
+      assert Repo.get!(DraftPick, pick.id).fantasy_player_id == nil
+    end
+
+    test "an unavailable player surfaces a validation tool result", %{conn: conn} do
+      %{league: league, team: team, player: player, pick: pick} = setup_draft_data()
+      other_team = insert(:fantasy_team, fantasy_league: league)
+
+      insert(:draft_pick,
+        draft_position: 1.02,
+        fantasy_team: other_team,
+        fantasy_league: league,
+        fantasy_player: player
+      )
+
+      user = insert(:user)
+      insert(:owner, fantasy_team: team, user: user)
+
+      conn =
+        call_tool(conn, user, "draft_player", %{
+          draft_pick_id: pick.id,
+          fantasy_player_id: player.id
+        })
+
+      assert %{"result" => %{"isError" => true, "content" => [content]}} =
+               json_response(conn, 200)
+
+      assert content["text"] =~ "Validation failed"
+      assert Repo.get!(DraftPick, pick.id).fantasy_player_id == nil
+    end
+
+    test "omitting the player surfaces a validation tool result, not a crash", %{conn: conn} do
+      %{team: team, pick: pick} = setup_draft_data()
+      user = insert(:user)
+      insert(:owner, fantasy_team: team, user: user)
+
+      conn = call_tool(conn, user, "draft_player", %{draft_pick_id: pick.id})
+
+      assert %{"result" => %{"isError" => true, "content" => [content]}} =
+               json_response(conn, 200)
+
+      assert content["text"] =~ "Validation failed"
+      assert Repo.get!(DraftPick, pick.id).fantasy_player_id == nil
+    end
+
+    test "a player that doesn't exist surfaces a validation result, not a crash", %{conn: conn} do
+      %{team: team, pick: pick} = setup_draft_data()
+      user = insert(:user)
+      insert(:owner, fantasy_team: team, user: user)
+
+      conn =
+        call_tool(conn, user, "draft_player", %{
+          draft_pick_id: pick.id,
+          fantasy_player_id: 999_999
+        })
+
+      assert %{"result" => %{"isError" => true, "content" => [content]}} =
+               json_response(conn, 200)
+
+      assert content["text"] =~ "Validation failed"
+      assert Repo.get!(DraftPick, pick.id).fantasy_player_id == nil
+    end
+
+    test "a pick with no team assigned is refused, not a crash", %{conn: conn} do
+      league = insert(:fantasy_league)
+      player = insert(:fantasy_player)
+      pick = insert(:draft_pick, draft_position: 1.01, fantasy_league: league, fantasy_team: nil)
+      admin = insert(:user, admin: true)
+
+      conn =
+        call_tool(conn, admin, "draft_player", %{
+          draft_pick_id: pick.id,
+          fantasy_player_id: player.id
+        })
+
+      assert %{"result" => %{"isError" => true, "content" => [content]}} =
+               json_response(conn, 200)
+
+      assert content["text"] =~ "Validation failed"
+      assert Repo.get!(DraftPick, pick.id).fantasy_player_id == nil
+    end
+
+    test "a missing draft pick returns a not-found tool result", %{conn: conn} do
+      user = insert(:user)
+
+      conn = call_tool(conn, user, "draft_player", %{draft_pick_id: 0, fantasy_player_id: 1})
+
+      assert %{"result" => %{"isError" => true, "content" => [content]}} =
+               json_response(conn, 200)
+
+      assert content["text"] =~ "Not found"
+    end
+  end
+
+  describe "tools/call update_draft_pick" do
+    test "an admin can correct a pick's fields", %{conn: conn} do
+      %{league: league, pick: pick} = setup_draft_data()
+      other_team = insert(:fantasy_team, fantasy_league: league)
+      admin = insert(:user, admin: true)
+
+      conn =
+        call_tool(conn, admin, "update_draft_pick", %{
+          draft_pick_id: pick.id,
+          fantasy_team_id: other_team.id,
+          draft_position: 2.05,
+          is_keeper: true
+        })
+
+      assert %{"result" => %{"isError" => false, "content" => [content]}} =
+               json_response(conn, 200)
+
+      assert Jason.decode!(content["text"])["is_keeper"] == true
+
+      updated_pick = Repo.get!(DraftPick, pick.id)
+      assert updated_pick.fantasy_team_id == other_team.id
+      assert updated_pick.draft_position == 2.05
+      assert updated_pick.is_keeper == true
+
+      assert [entry] = Audit.list_for_user(admin.id)
+      assert entry.action == "draft_pick.update"
+      assert entry.source == "mcp"
+      assert entry.outcome == "success"
+    end
+
+    test "an admin can update a pick in a locked league", %{conn: conn} do
+      %{pick: pick} = setup_draft_data(draft_picks_locked?: true)
+      admin = insert(:user, admin: true)
+
+      conn =
+        call_tool(conn, admin, "update_draft_pick", %{draft_pick_id: pick.id, is_keeper: true})
+
+      assert %{"result" => %{"isError" => false}} = json_response(conn, 200)
+      assert Repo.get!(DraftPick, pick.id).is_keeper == true
+    end
+
+    test "an owner cannot update their own pick's fields", %{conn: conn} do
+      %{team: team, pick: pick} = setup_draft_data()
+      user = insert(:user)
+      insert(:owner, fantasy_team: team, user: user)
+
+      conn =
+        call_tool(conn, user, "update_draft_pick", %{draft_pick_id: pick.id, is_keeper: true})
+
+      assert %{"result" => %{"isError" => true, "content" => [content]}} =
+               json_response(conn, 200)
+
+      assert content["text"] =~ "not authorized"
+      assert Repo.get!(DraftPick, pick.id).is_keeper == false
+
+      assert [entry] = Audit.list_for_user(user.id)
+      assert entry.outcome == "denied"
+    end
+
+    test "the drafted player cannot be changed", %{conn: conn} do
+      %{league: league, team: team, player: player} = setup_draft_data()
+      other_player = insert(:fantasy_player)
+
+      pick =
+        insert(:draft_pick,
+          draft_position: 1.01,
+          fantasy_league: league,
+          fantasy_team: team,
+          fantasy_player: player
+        )
+
+      admin = insert(:user, admin: true)
+
+      conn =
+        call_tool(conn, admin, "update_draft_pick", %{
+          draft_pick_id: pick.id,
+          fantasy_player_id: other_player.id
+        })
+
+      assert %{"result" => %{"isError" => false}} = json_response(conn, 200)
+      assert Repo.get!(DraftPick, pick.id).fantasy_player_id == player.id
+    end
+
+    test "clearing the team is refused", %{conn: conn} do
+      %{pick: pick} = setup_draft_data()
+      admin = insert(:user, admin: true)
+
+      conn =
+        call_tool(conn, admin, "update_draft_pick", %{
+          draft_pick_id: pick.id,
+          fantasy_team_id: nil
+        })
+
+      assert %{"result" => %{"isError" => true, "content" => [content]}} =
+               json_response(conn, 200)
+
+      assert content["text"] =~ "Validation failed"
+      refute is_nil(Repo.get!(DraftPick, pick.id).fantasy_team_id)
+    end
+
+    test "a team from another league is refused", %{conn: conn} do
+      %{team: team, pick: pick} = setup_draft_data()
+      other_league_team = insert(:fantasy_team, fantasy_league: insert(:fantasy_league))
+      admin = insert(:user, admin: true)
+
+      conn =
+        call_tool(conn, admin, "update_draft_pick", %{
+          draft_pick_id: pick.id,
+          fantasy_team_id: other_league_team.id
+        })
+
+      assert %{"result" => %{"isError" => true, "content" => [content]}} =
+               json_response(conn, 200)
+
+      assert content["text"] =~ "must belong to the pick's league"
+      assert Repo.get!(DraftPick, pick.id).fantasy_team_id == team.id
+    end
+
+    test "a team that doesn't exist is refused, not a crash", %{conn: conn} do
+      %{team: team, pick: pick} = setup_draft_data()
+      admin = insert(:user, admin: true)
+
+      conn =
+        call_tool(conn, admin, "update_draft_pick", %{
+          draft_pick_id: pick.id,
+          fantasy_team_id: 999_999
+        })
+
+      assert %{"result" => %{"isError" => true, "content" => [content]}} =
+               json_response(conn, 200)
+
+      assert content["text"] =~ "does not exist"
+      assert Repo.get!(DraftPick, pick.id).fantasy_team_id == team.id
+    end
+
+    test "the league cannot be reassigned", %{conn: conn} do
+      %{league: league, pick: pick} = setup_draft_data()
+      other_league = insert(:fantasy_league)
+      admin = insert(:user, admin: true)
+
+      conn =
+        call_tool(conn, admin, "update_draft_pick", %{
+          draft_pick_id: pick.id,
+          fantasy_league_id: other_league.id
+        })
+
+      assert %{"result" => %{"isError" => false}} = json_response(conn, 200)
+      assert Repo.get!(DraftPick, pick.id).fantasy_league_id == league.id
     end
   end
 


### PR DESCRIPTION
Owners and admins can now make a draft pick over the authenticated API and MCP, and admins can correct the draft board.

## What's added

All three go through the shared, audited `Ex338Web.ApiActions`, so REST and MCP share one implementation and one audit trail.

| | `draft_player` | `update_draft_pick` |
|---|---|---|
| Who | Owners (own picks) + admins (any) | **Admins only** |
| Rules | Pick must be up (or reachable via skipped teams), flex spot available, not already drafted | Bypasses them |
| Side effects | Roster position, draft queue updates, league email, autodraft | None — writes the pick row only |
| Locked league | Refused | Allowed (it's the correction path) |

Plus `list_league_draft_picks` — the board with `available_to_pick?`, so an MCP client can find which pick is up. Scoped by `can_access_league?/2` like the other league reads.

REST: `POST /api/v1/draft_picks/:id/draft_player` and `PATCH /api/v1/draft_picks/:id`.

## Design note

A correction path that writes one row still owes the invariants of everything that row is joined to. `DraftPick.changeset/2` was written for trusted internal callers and has no FK constraints or null guards, so exposing it directly turned each gap into a 500 or a corrupt board. The invariants now live in a new `DraftPick.admin_changeset/2`:

- **The drafted player isn't castable.** Its roster position isn't touched here, so clearing or changing it would orphan the position, reopen the pick, and let two teams own one player (double-counting in standings). Changing who was drafted goes through `draft_player/4`.
- **The team can't move once the pick has been used** — same reason.
- **The team must be present and in the pick's own league.** A null team makes `DraftPicks.Clock` raise, permanently 500ing the draft board, the REST index *and* the new list tool for that league; a foreign team puts another league's team in the draft order.
- **The league stays frozen** — moving a pick between leagues would orphan it from the roster positions and audit entries created under it.

`owner_changeset/2` now verifies the drafted player exists before running the rules that load it, so an unknown id is a 422 rather than a 500 raised while the Multi is built.

`DraftPicks.update_draft_pick/2` deliberately does not broadcast. The `"draft_pick"` topic's events mean a pick was *made*, and `DraftPickLive.Index` renders the drafting team and player from them — fields a corrected pick may not have, which would kill every viewer's LiveView. Open boards pick the change up on their existing 60-second refresh.

## Known gap

`draft_player` does not check the player against `FantasyPlayers.available_players/1` — that filter only ever existed as the HTML form's select options, so this predates the PR. An API/MCP caller can therefore draft an inactive or out-of-season player. The tool description says so explicitly rather than implying a check that isn't there. Adding a real check would change the shared HTML and autodraft paths, so it's flagged in `docs/api-and-mcp.md` as its own decision.

## Testing

1048 tests passing, format and `--warnings-as-errors` clean. New coverage on both transports for: owner/admin success, non-owner 403 with the denial audited, locked league, missing/nonexistent player, team-less pick, cleared team, cross-league team, nonexistent team, moving a used pick, and that the player and league can't be reassigned. Three existing `owner_changeset/2` unit tests that asserted validity for a fabricated player id were updated to insert a real player.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RJKRr9sX9vFMaaA4at75Ez