### PR TITLE
Return the caller's teams from whoami and /api/v1/me

### DIFF
--- a/docs/api-and-mcp.md
+++ b/docs/api-and-mcp.md
@@ -115,6 +115,18 @@ positions, the clock, unique indexes) and put those checks in an `admin_changese
 schema's plain `changeset/2` was written for trusted internal callers and usually has no
 FK constraints or null guards at all.
 
+**Discovery matters as much as capability.** Every team-scoped tool takes a
+`fantasy_team_id`, so a client that can't map "my B league team" to an id can't use any
+of them — and an owner with teams in two leagues will pick the wrong one. So `whoami`
+(and REST `GET /api/v1/me`) return the user's teams with each team's league, and every
+team-scoped result carries `team_name` + `fantasy_league_id` rather than a bare id the
+caller can't verify. When adding a tool, ask how a client learns the ids it needs; no
+amount of client-side code can recover data the tool surface never exposes.
+
+Still not discoverable over MCP: the league list. An admin acting across leagues has to
+get league ids elsewhere (the public `GET /api/v1/fantasy_leagues`). Worth a
+`list_leagues` tool if admin workflows grow.
+
 Known gap: `draft_player` does not check the player against
 `FantasyPlayers.available_players/1` (that filter only ever existed as the HTML form's
 select options), so an API/MCP caller can draft an inactive or out-of-season player. The
@@ -168,6 +180,8 @@ audited uniformly.
 - Auth: `Authorization: Bearer <personal access token>` (generate under Account Settings →
   API Tokens). The token carries the user's scope: owners act on their own teams, admins on
   any team.
+- Start with `whoami` — it returns the caller's teams and the league each plays in, which is
+  where the `fantasy_team_id` every other tool wants comes from.
 
 ## Deferred / future
 

--- a/lib/ex338_web/controllers/api/v1/mcp/tools.ex
+++ b/lib/ex338_web/controllers/api/v1/mcp/tools.ex
@@ -11,6 +11,7 @@ defmodule Ex338Web.Api.V1.Mcp.Tools do
   `Ex338Web.Plugs.ApiAuth`) and returns a tagged result the MCP controller maps
   onto the JSON-RPC/tool-result envelope.
   """
+  alias Ex338.Accounts
   alias Ex338.DraftPicks
   alias Ex338.DraftQueues
   alias Ex338.FantasyLeagues
@@ -27,7 +28,10 @@ defmodule Ex338Web.Api.V1.Mcp.Tools do
       %{
         name: "whoami",
         description:
-          "Return the authenticated user's identity and whether they have admin scope.",
+          "Return the authenticated user's identity, whether they have admin scope, and the " <>
+            "fantasy teams they own with the league each team plays in. Call this first: every " <>
+            "team-scoped tool needs a fantasy_team_id, and an owner may have teams in more than " <>
+            "one league, so use this to map their teams to ids before acting on one.",
         inputSchema: %{type: "object", properties: %{}, additionalProperties: false}
       },
       %{
@@ -50,7 +54,7 @@ defmodule Ex338Web.Api.V1.Mcp.Tools do
         inputSchema: %{
           type: "object",
           properties: %{
-            fantasy_team_id: %{type: "integer", description: "The fantasy team id"},
+            fantasy_team_id: %{type: "integer", description: "The fantasy team id (from whoami)"},
             add_fantasy_player_id: %{type: "integer", description: "Player to add (optional)"},
             drop_fantasy_player_id: %{type: "integer", description: "Player to drop (optional)"}
           },
@@ -78,7 +82,7 @@ defmodule Ex338Web.Api.V1.Mcp.Tools do
         inputSchema: %{
           type: "object",
           properties: %{
-            fantasy_team_id: %{type: "integer", description: "The fantasy team id"},
+            fantasy_team_id: %{type: "integer", description: "The fantasy team id (from whoami)"},
             injured_player_id: %{type: "integer", description: "The injured player to move to IR"},
             replacement_player_id: %{
               type: "integer",
@@ -96,7 +100,9 @@ defmodule Ex338Web.Api.V1.Mcp.Tools do
             "to the team's owners and admins.",
         inputSchema: %{
           type: "object",
-          properties: %{fantasy_team_id: %{type: "integer", description: "The fantasy team id"}},
+          properties: %{
+            fantasy_team_id: %{type: "integer", description: "The fantasy team id (from whoami)"}
+          },
           required: ["fantasy_team_id"],
           additionalProperties: false
         }
@@ -109,7 +115,7 @@ defmodule Ex338Web.Api.V1.Mcp.Tools do
         inputSchema: %{
           type: "object",
           properties: %{
-            fantasy_team_id: %{type: "integer", description: "The fantasy team id"},
+            fantasy_team_id: %{type: "integer", description: "The fantasy team id (from whoami)"},
             fantasy_player_id: %{type: "integer", description: "The player to queue"}
           },
           required: ["fantasy_team_id", "fantasy_player_id"],
@@ -187,7 +193,16 @@ defmodule Ex338Web.Api.V1.Mcp.Tools do
   `{:error, {:invalid_params, message}}`, or `{:error, %Ecto.Changeset{}}`.
   """
   def call("whoami", _args, %{user: user}) do
-    {:ok, %{id: user.id, name: user.name, email: user.email, admin: user.admin}}
+    user = Accounts.load_user_teams(user)
+
+    {:ok,
+     %{
+       id: user.id,
+       name: user.name,
+       email: user.email,
+       admin: user.admin,
+       fantasy_teams: Enum.map(user.fantasy_teams, &user_team_summary/1)
+     }}
   end
 
   def call("list_league_waivers", %{"fantasy_league_id" => league_id}, %{user: user}) do
@@ -323,23 +338,29 @@ defmodule Ex338Web.Api.V1.Mcp.Tools do
   end
 
   defp waiver_summary(waiver) do
-    %{
-      id: waiver.id,
-      status: waiver.status,
-      fantasy_team_id: waiver.fantasy_team_id,
-      add_fantasy_player_id: waiver.add_fantasy_player_id,
-      drop_fantasy_player_id: waiver.drop_fantasy_player_id
-    }
+    Map.merge(
+      %{
+        id: waiver.id,
+        status: waiver.status,
+        fantasy_team_id: waiver.fantasy_team_id,
+        add_fantasy_player_id: waiver.add_fantasy_player_id,
+        drop_fantasy_player_id: waiver.drop_fantasy_player_id
+      },
+      team_fields(waiver.fantasy_team)
+    )
   end
 
   defp ir_summary(injured_reserve) do
-    %{
-      id: injured_reserve.id,
-      status: injured_reserve.status,
-      fantasy_team_id: injured_reserve.fantasy_team_id,
-      injured_player_id: injured_reserve.injured_player_id,
-      replacement_player_id: injured_reserve.replacement_player_id
-    }
+    Map.merge(
+      %{
+        id: injured_reserve.id,
+        status: injured_reserve.status,
+        fantasy_team_id: injured_reserve.fantasy_team_id,
+        injured_player_id: injured_reserve.injured_player_id,
+        replacement_player_id: injured_reserve.replacement_player_id
+      },
+      team_fields(injured_reserve.fantasy_team)
+    )
   end
 
   defp draft_pick_summary(draft_pick) do
@@ -371,12 +392,43 @@ defmodule Ex338Web.Api.V1.Mcp.Tools do
   defp assoc_field(assoc, field), do: Map.get(assoc, field)
 
   defp draft_queue_summary(draft_queue) do
+    Map.merge(
+      %{
+        id: draft_queue.id,
+        order: draft_queue.order,
+        status: draft_queue.status,
+        fantasy_team_id: draft_queue.fantasy_team_id,
+        fantasy_player_id: draft_queue.fantasy_player_id
+      },
+      team_fields(draft_queue.fantasy_team)
+    )
+  end
+
+  # A bare fantasy_team_id is ambiguous for an owner with teams in more than one
+  # league, so every team-scoped result names its team and the league it plays in.
+  defp team_fields(fantasy_team) do
     %{
-      id: draft_queue.id,
-      order: draft_queue.order,
-      status: draft_queue.status,
-      fantasy_team_id: draft_queue.fantasy_team_id,
-      fantasy_player_id: draft_queue.fantasy_player_id
+      team_name: assoc_field(fantasy_team, :team_name),
+      fantasy_league_id: assoc_field(fantasy_team, :fantasy_league_id)
     }
   end
+
+  defp user_team_summary(fantasy_team) do
+    %{
+      id: fantasy_team.id,
+      team_name: fantasy_team.team_name,
+      fantasy_league: user_league_summary(fantasy_team.fantasy_league)
+    }
+  end
+
+  defp user_league_summary(%{id: id} = fantasy_league) do
+    %{
+      id: id,
+      fantasy_league_name: fantasy_league.fantasy_league_name,
+      division: fantasy_league.division,
+      year: fantasy_league.year
+    }
+  end
+
+  defp user_league_summary(_not_loaded), do: nil
 end

--- a/lib/ex338_web/controllers/api/v1/me_controller.ex
+++ b/lib/ex338_web/controllers/api/v1/me_controller.ex
@@ -1,13 +1,17 @@
 defmodule Ex338Web.Api.V1.MeController do
   use Ex338Web, :controller
 
+  alias Ex338.Accounts
+
   action_fallback Ex338Web.Api.V1.FallbackController
 
   @doc """
-  Returns the authenticated user. Lets a client confirm its API token is valid
-  and learn whether it has admin scope.
+  Returns the authenticated user with the teams they own. Lets a client confirm
+  its API token is valid, learn whether it has admin scope, and map the user's
+  teams to the ids every team-scoped endpoint needs.
   """
   def show(conn, _params) do
-    render(conn, :show, user: conn.assigns.current_user)
+    user = Accounts.load_user_teams(conn.assigns.current_user)
+    render(conn, :show, user: user)
   end
 end

--- a/lib/ex338_web/controllers/api/v1/me_json.ex
+++ b/lib/ex338_web/controllers/api/v1/me_json.ex
@@ -8,7 +8,27 @@ defmodule Ex338Web.Api.V1.MeJSON do
       id: user.id,
       name: user.name,
       email: user.email,
-      admin: user.admin
+      admin: user.admin,
+      fantasy_teams: Enum.map(user.fantasy_teams, &team_data/1)
     }
   end
+
+  defp team_data(team) do
+    %{
+      id: team.id,
+      team_name: team.team_name,
+      fantasy_league: league_data(team.fantasy_league)
+    }
+  end
+
+  defp league_data(%{id: id} = league) do
+    %{
+      id: id,
+      fantasy_league_name: league.fantasy_league_name,
+      division: league.division,
+      year: league.year
+    }
+  end
+
+  defp league_data(_not_loaded), do: nil
 end

--- a/test/ex338_web/controllers/api/v1/mcp_controller_test.exs
+++ b/test/ex338_web/controllers/api/v1/mcp_controller_test.exs
@@ -123,6 +123,43 @@ defmodule Ex338Web.Api.V1.McpControllerTest do
       assert content["type"] == "text"
       assert Jason.decode!(content["text"])["admin"] == true
     end
+
+    test "returns each team the owner has with the league it plays in", %{conn: conn} do
+      user = insert(:user)
+      league_b = insert(:fantasy_league, fantasy_league_name: "2027 Div B", division: "B")
+      league_c = insert(:fantasy_league, fantasy_league_name: "2027 Div C", division: "C")
+      team_b = insert(:fantasy_team, team_name: "B Squad", fantasy_league: league_b)
+      team_c = insert(:fantasy_team, team_name: "C Squad", fantasy_league: league_c)
+      insert(:owner, fantasy_team: team_b, user: user)
+      insert(:owner, fantasy_team: team_c, user: user)
+
+      conn = call_tool(conn, user, "whoami", %{})
+
+      assert %{"result" => %{"isError" => false, "content" => [content]}} =
+               json_response(conn, 200)
+
+      teams = Jason.decode!(content["text"])["fantasy_teams"]
+      assert length(teams) == 2
+
+      by_name = Map.new(teams, &{&1["team_name"], &1})
+      assert by_name["B Squad"]["id"] == team_b.id
+      assert by_name["B Squad"]["fantasy_league"]["id"] == league_b.id
+      assert by_name["B Squad"]["fantasy_league"]["division"] == "B"
+      assert by_name["C Squad"]["id"] == team_c.id
+      assert by_name["C Squad"]["fantasy_league"]["id"] == league_c.id
+      assert by_name["C Squad"]["fantasy_league"]["division"] == "C"
+    end
+
+    test "returns an empty team list for a user who owns none", %{conn: conn} do
+      user = insert(:user)
+
+      conn = call_tool(conn, user, "whoami", %{})
+
+      assert %{"result" => %{"isError" => false, "content" => [content]}} =
+               json_response(conn, 200)
+
+      assert Jason.decode!(content["text"])["fantasy_teams"] == []
+    end
   end
 
   describe "tools/call create_waiver" do
@@ -141,7 +178,10 @@ defmodule Ex338Web.Api.V1.McpControllerTest do
       assert %{"result" => %{"isError" => false, "content" => [content]}} =
                json_response(conn, 200)
 
-      assert Jason.decode!(content["text"])["fantasy_team_id"] == team.id
+      data = Jason.decode!(content["text"])
+      assert data["fantasy_team_id"] == team.id
+      assert data["team_name"] == team.team_name
+      assert data["fantasy_league_id"] == team.fantasy_league_id
       assert Repo.get_by(Waiver, fantasy_team_id: team.id)
 
       assert [entry] = Audit.list_for_user(user.id)
@@ -277,7 +317,9 @@ defmodule Ex338Web.Api.V1.McpControllerTest do
       assert %{"result" => %{"isError" => false, "content" => [content]}} =
                json_response(conn, 200)
 
-      assert length(Jason.decode!(content["text"])["draft_queues"]) == 1
+      assert [queue] = Jason.decode!(content["text"])["draft_queues"]
+      assert queue["team_name"] == team.team_name
+      assert queue["fantasy_league_id"] == team.fantasy_league_id
     end
 
     test "a non-owner cannot read another team's queue", %{conn: conn} do

--- a/test/ex338_web/controllers/api/v1/me_controller_test.exs
+++ b/test/ex338_web/controllers/api/v1/me_controller_test.exs
@@ -31,6 +31,43 @@ defmodule Ex338Web.Api.V1.MeControllerTest do
       assert json_response(conn, 200)["user"]["admin"] == true
     end
 
+    test "returns each team the owner has with the league it plays in", %{conn: conn} do
+      user = insert(:user)
+      league_b = insert(:fantasy_league, division: "B")
+      league_c = insert(:fantasy_league, division: "C")
+      team_b = insert(:fantasy_team, team_name: "B Squad", fantasy_league: league_b)
+      team_c = insert(:fantasy_team, team_name: "C Squad", fantasy_league: league_c)
+      insert(:owner, fantasy_team: team_b, user: user)
+      insert(:owner, fantasy_team: team_c, user: user)
+      token = Accounts.create_user_api_token(user, "test")
+
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer " <> token)
+        |> get(~p"/api/v1/me")
+
+      assert %{"user" => %{"fantasy_teams" => teams}} = json_response(conn, 200)
+      assert length(teams) == 2
+
+      by_name = Map.new(teams, &{&1["team_name"], &1})
+      assert by_name["B Squad"]["id"] == team_b.id
+      assert by_name["B Squad"]["fantasy_league"]["id"] == league_b.id
+      assert by_name["B Squad"]["fantasy_league"]["division"] == "B"
+      assert by_name["C Squad"]["fantasy_league"]["id"] == league_c.id
+    end
+
+    test "returns an empty team list for a user who owns none", %{conn: conn} do
+      user = insert(:user)
+      token = Accounts.create_user_api_token(user, "test")
+
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer " <> token)
+        |> get(~p"/api/v1/me")
+
+      assert json_response(conn, 200)["user"]["fantasy_teams"] == []
+    end
+
     test "returns 401 when the token is missing", %{conn: conn} do
       conn = get(conn, ~p"/api/v1/me")
 


### PR DESCRIPTION
An owner with teams in two leagues (B and C) couldn't get their assistant to work out which team was which, or which league each was in. That's a real gap in the tool surface, not a client problem.

## The gap

Every team-scoped tool *takes* a `fantasy_team_id`:

- `whoami` returned only `{id, name, email, admin}` — no teams
- No `list_my_teams` tool, and no `list_leagues` tool either
- Results came back as bare ids — `{"fantasy_team_id": 810, ...}` — so even once told "use 810", a client had nothing to confirm it acted on the right team

Net effect: "which of my teams is in B?" is **unanswerable** over MCP. Concretely, every league id used while testing this server came from the *public REST* endpoint, not MCP — league 101 is not reachable through the MCP server at all.

## The fix

The data was already plumbed — `Accounts.load_user_teams/1` backs the web nav via the `LoadUserTeams` plug — so this is small:

1. **`whoami` and `GET /api/v1/me`** return `fantasy_teams: [{id, team_name, fantasy_league: {id, fantasy_league_name, division, year}}]`. One call now maps an owner's teams to ids and leagues. Both transports changed together so they don't drift.
2. **Waiver / IR / draft-queue results** carry `team_name` and `fantasy_league_id` next to `fantasy_team_id`, so results are self-describing. Draft pick results already were.
3. **Descriptions steer the client** — `whoami` says to call it first; the `fantasy_team_id` params say "(from whoami)".

## Notes

- `team_fields/1` reads `fantasy_league_id` off the already-preloaded team rather than preloading the league, so no query patterns changed. All three summaries' context functions already preload `fantasy_team`.
- Still not discoverable over MCP: the league list. An admin working across leagues needs the public `GET /api/v1/fantasy_leagues`. Flagged in `docs/api-and-mcp.md` as a candidate `list_leagues` tool rather than guessed at here.
- This is the class of problem client-side code execution can't solve — no amount of local filtering recovers data the server never exposes. Noted in the docs so future tools get the discovery question asked up front.

## Testing

1052 tests passing, format and `--warnings-as-errors` clean. New tests cover exactly the reported situation — a user owning teams in two different leagues gets both back with distinct leagues and divisions, on both `whoami` and `/api/v1/me` — plus the empty case for a user who owns none, and assertions that waiver and queue results name their team and league.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RJKRr9sX9vFMaaA4at75Ez