### PR TITLE
Cut Render restart cost and pin the deployed plans

### DIFF
--- a/config/prod.exs
+++ b/config/prod.exs
@@ -11,5 +11,13 @@ config :ex338, plausible_analytics: true
 # Do not print debug messages in production
 config :logger, level: :info
 
+# Render's filesystem is ephemeral, so Tzdata's autoupdate re-downloaded and
+# rebuilt the tz release on every boot, adding ~15s to each restart and throwing
+# the work away when the instance went. Use the data bundled with the dep
+# instead — tzdata 1.1.3 ships 2025a, which has correct America/Los_Angeles DST
+# rules through 2027 (the Oban waiver cron is the only tz-sensitive path).
+# Refresh by bumping `:tzdata`, not at runtime.
+config :tzdata, :autoupdate, :disabled
+
 # Runtime production configuration, including reading
 # of environment variables, is done on config/runtime.exs.

--- a/render.yaml
+++ b/render.yaml
@@ -1,6 +1,6 @@
 databases:
   - name: ex338-db
-    plan: basic-1gb
+    plan: basic_256mb
     databaseName: ex338
     postgresMajorVersion: "16"
 
@@ -8,6 +8,10 @@ services:
   - type: web
     name: ex338
     runtime: elixir
+    # 2 GB / 1 CPU. The 512 MB starter plan OOM-killed the instance dozens of
+    # times a day once the 2027 draft started, when concurrent draft boards
+    # pushed memory from a ~230 MB baseline to ~500 MB peaks.
+    plan: standard
     buildCommand: ./build.sh
     startCommand: _build/prod/rel/ex338/bin/migrate && _build/prod/rel/ex338/bin/server
     healthCheckPath: /health

--- a/render.yaml
+++ b/render.yaml
@@ -13,7 +13,11 @@ services:
     # pushed memory from a ~230 MB baseline to ~500 MB peaks.
     plan: standard
     buildCommand: ./build.sh
-    startCommand: _build/prod/rel/ex338/bin/migrate && _build/prod/rel/ex338/bin/server
+    # Migrations belong in preDeploy, not startCommand: startCommand runs on
+    # every restart, so migrations were re-running on each OOM recovery and
+    # adding to the outage.
+    preDeployCommand: _build/prod/rel/ex338/bin/migrate
+    startCommand: _build/prod/rel/ex338/bin/server
     healthCheckPath: /health
     envVars:
       - key: DATABASE_URL


### PR DESCRIPTION
## Why

The site was returning 502s every 5–15 minutes during the annual draft. Render's
service events show the cause: the instance was being OOM-killed at a 512 Mi
limit, dozens of times a day.

```
server_failed  {"reason": {"oomKilled": {"memoryLimit": "512Mi"}}}
```

Restarts per day, from Render events: 0, 0, 0 (07-22..24), then 2, 7, 47, 28 as
the draft ramped up. Memory was flat at a ~230 MB baseline before the draft and
peaked at 499 MB (98% of the cap) on 07-28. CPU was never a factor — median
0.017 of 0.5 cores.

The service has been moved to the `standard` plan (2 GB / 1 CPU) out of band,
since the site was actively down. This PR records that in the blueprint and
removes two things that made each restart longer than it needed to be.

## What's here

**`Pin the deployed Render plans in render.yaml`** — the blueprint had drifted
badly enough that a sync was a hazard rather than a no-op: the web service
declared no `plan`, and the database claimed `basic-1gb` while the real instance
is `basic_256mb`, so a sync could have silently upsized the database.

**`Stop redoing migrations and tzdata setup on every restart`** — migrations
were in `startCommand`, which runs on every restart, so they re-ran on each OOM
recovery; they move to `preDeployCommand`. Tzdata's autoupdate re-downloaded and
rebuilt the tz release on each boot into an ephemeral filesystem; disabled in
prod.

## Verification

- `mix format --check-formatted`, `mix compile --warnings-as-errors` in both dev
  and prod, `render.yaml` parses.
- tzdata 1.1.3 bundles 2025a. Checked against the pristine package (a local
  autoupdate had already overwritten `deps/`, which is misleading): it resolves
  `America/Los_Angeles` correctly across both 2027 DST transitions, which is
  what the 10pm Pacific Oban waiver cron depends on.
- `mix test` was **not** run locally — no Postgres or Docker available. The diff
  is prod-only config plus infra YAML, and `config/prod.exs` isn't loaded in the
  `test` env, so CI covers it.
- The live service already has the `preDeployCommand` / `startCommand` split
  applied via the API, and a deploy confirmed it: `pre_deploy_started` →
  `pre_deploy_ended: succeeded`.

## Not in scope

The largest remaining memory consumer is untouched: every connected draft board
has its own 60s timer that re-runs `DraftPicks.get_picks_for_league/1`, a full
league query with preloads, and refetches the whole league again on every pick
broadcast. Fixing it needs care, because `DraftPicks.update_draft_pick/2`
deliberately doesn't broadcast and relies on that poll to reach open boards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WLPc63M43qGVBygzKvXwsc