### PR TITLE
Re-enable Tzdata autoupdate in production

### DIFF
--- a/config/prod.exs
+++ b/config/prod.exs
@@ -11,13 +11,15 @@ config :ex338, plausible_analytics: true
 # Do not print debug messages in production
 config :logger, level: :info
 
-# Render's filesystem is ephemeral, so Tzdata's autoupdate re-downloaded and
-# rebuilt the tz release on every boot, adding ~15s to each restart and throwing
-# the work away when the instance went. Use the data bundled with the dep
-# instead — tzdata 1.1.3 ships 2025a, which has correct America/Los_Angeles DST
-# rules through 2027 (the Oban waiver cron is the only tz-sensitive path).
-# Refresh by bumping `:tzdata`, not at runtime.
-config :tzdata, :autoupdate, :disabled
+# Tzdata's autoupdate is left on deliberately. Disabling it to save boot time
+# pinned production to the 2025a release bundled with tzdata 1.1.3 — older than
+# the 2026c the updater had been fetching on each boot, with no newer :tzdata to
+# bump to. Correct timezone data beats a faster restart.
+#
+# The cost is real: Render's filesystem is ephemeral, so the download and rebuild
+# happens on every boot (~15s) and never persists. If that matters again, bake the
+# release into the artifact from build.sh — the data lands in _build/prod/lib/
+# tzdata/priv, which mix release packages — rather than freezing the data.
 
 # Runtime production configuration, including reading
 # of environment variables, is done on config/runtime.exs.


### PR DESCRIPTION
Reverts `config :tzdata, :autoupdate, :disabled` from 649deb2d.

## Why

Disabling autoupdate saved ~15s per boot, but the boot logs show what it actually traded away:

```
00:45:08  Tzdata has updated the release from 2025a to 2026c
00:59:33  Tzdata has updated the release from 2025a to 2026c
03:58:08  Tzdata has updated the release from 2025a to 2026c   <- last boot with autoupdate on
05:09:54  tzdata 1.1.3                                          <- first boot with it off
```

Production had been running **2026c** and is now pinned to the **2025a** release bundled with `tzdata 1.1.3`. The commit's escape hatch — "refresh by bumping `:tzdata`" — doesn't currently lead anywhere, since 1.1.3 is the latest and still ships 2025a.

The stated justification (2025a has correct `America/Los_Angeles` rules through 2027, and the 22:00 Pacific Oban waiver cron is the only timezone-sensitive path) is true today, but it's a silent bet on US DST rules not changing and on nothing new in the app needing another zone.

## What this doesn't fix

The boot cost is real and comes back: Render's filesystem is ephemeral, so the download and rebuild runs on every start and never persists. The way to get both current data and a fast boot is to bake the tz release into the build artifact from `build.sh` — the data lands in `_build/prod/lib/tzdata/priv`, which `mix release` packages — instead of freezing it. Left as a follow-up; it needs `--no-start` so the build doesn't boot the Repo, and the updater has to be driven explicitly.

The `render.yaml` half of 649deb2d (pinned plans, pre-deploy migrate) is untouched — it accurately documents the live service config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G4NS9QLtfS6L8rcscXgmQB