### PR TITLE
Default new fantasy teams to autodraft off

### DIFF
--- a/lib/ex338/fantasy_teams/fantasy_team.ex
+++ b/lib/ex338/fantasy_teams/fantasy_team.ex
@@ -24,7 +24,7 @@ defmodule Ex338.FantasyTeams.FantasyTeam do
     field(:winnings_received, :float, default: 0.0)
     field(:max_flex_adj, :integer, default: 0)
     field(:commish_notes, :string)
-    field(:autodraft_setting, FantasyTeamAutodraftSettingEnum, default: "on")
+    field(:autodraft_setting, FantasyTeamAutodraftSettingEnum, default: "off")
     field(:slot_results, {:array, :map}, virtual: true, default: [])
     field(:total_seconds_on_the_clock, :integer, virtual: true, default: 0)
     field(:avg_seconds_on_the_clock, :integer, virtual: true, default: 0)

--- a/priv/repo/migrations/20260729120000_default_autodraft_setting_to_off.exs
+++ b/priv/repo/migrations/20260729120000_default_autodraft_setting_to_off.exs
@@ -1,0 +1,15 @@
+defmodule Ex338.Repo.Migrations.DefaultAutodraftSettingToOff do
+  use Ecto.Migration
+
+  def up do
+    alter table(:fantasy_teams) do
+      modify(:autodraft_setting, :fantasy_team_autodraft_setting, default: "off")
+    end
+  end
+
+  def down do
+    alter table(:fantasy_teams) do
+      modify(:autodraft_setting, :fantasy_team_autodraft_setting, default: "on")
+    end
+  end
+end


### PR DESCRIPTION
Autodraft defaulted to on, so owners who didn't realize it was enabled had a pick made for them as soon as they loaded a draft queue. New teams now start with it off and have to opt in.

- Schema default `autodraft_setting` `"on"` → `"off"`
- Migration flips the column default (reversible)

Existing teams keep whatever setting they already have.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G4NS9QLtfS6L8rcscXgmQB