### PR TITLE
Make the MCP endpoint's HTTP behavior spec-compliant

### DIFF
--- a/lib/ex338_web/controllers/api/v1/mcp_controller.ex
+++ b/lib/ex338_web/controllers/api/v1/mcp_controller.ex
@@ -29,6 +29,20 @@ defmodule Ex338Web.Api.V1.McpController do
     end
   end
 
+  @doc """
+  Rejects non-POST requests to the MCP endpoint with a 405 and an `Allow` header.
+
+  Routed outside the authenticated pipelines, so it answers before any token
+  check and without content negotiation — the method is wrong regardless of who
+  is asking.
+  """
+  def method_not_allowed(conn, _params) do
+    conn
+    |> put_resp_header("allow", "POST")
+    |> put_status(:method_not_allowed)
+    |> json(ErrorJSON.error(%{message: "Method not allowed, use POST"}))
+  end
+
   defp actor(conn) do
     %{user: conn.assigns.current_user, api_token: conn.assigns[:current_api_token]}
   end

--- a/lib/ex338_web/plugs/api_auth.ex
+++ b/lib/ex338_web/plugs/api_auth.ex
@@ -30,9 +30,15 @@ defmodule Ex338Web.Plugs.ApiAuth do
     end
   end
 
+  # RFC 7235 defines the auth scheme as case-insensitive, so compare it that way
+  # instead of pattern-matching the literal "Bearer ".
   defp fetch_bearer_token(conn) do
-    case get_req_header(conn, "authorization") do
-      ["Bearer " <> token | _] -> {:ok, String.trim(token)}
+    with [header | _] <- get_req_header(conn, "authorization"),
+         [scheme, token] <- String.split(header, " ", parts: 2),
+         "bearer" <- String.downcase(scheme),
+         token when token != "" <- String.trim(token) do
+      {:ok, token}
+    else
       _ -> :error
     end
   end

--- a/lib/ex338_web/router.ex
+++ b/lib/ex338_web/router.ex
@@ -241,4 +241,14 @@ defmodule Ex338Web.Router do
     post "/draft_picks/:id/draft_player", DraftPickController, :draft_player
     resources "/draft_picks", DraftPickController, only: [:update]
   end
+
+  # The MCP endpoint is POST-only: it implements the stateless Streamable HTTP
+  # transport, so there is no SSE stream for a client to GET. Answer every other
+  # method with 405 and an `Allow` header — a 404 here reads as a bad URL and
+  # sends people hunting for a typo instead of a method mismatch. Declared after
+  # the `post "/mcp"` route above so POST still reaches `:handle`, and outside the
+  # API pipelines so it needs no token and skips content negotiation.
+  scope "/api/v1", V1 do
+    match :*, "/mcp", McpController, :method_not_allowed
+  end
 end

--- a/test/ex338_web/controllers/api/v1/mcp_controller_test.exs
+++ b/test/ex338_web/controllers/api/v1/mcp_controller_test.exs
@@ -91,6 +91,41 @@ defmodule Ex338Web.Api.V1.McpControllerTest do
 
       assert json_response(conn, 401)["error"]
     end
+
+    test "accepts a lowercase bearer scheme", %{conn: conn} do
+      user = insert(:user)
+      token = Accounts.create_user_api_token(user, "test")
+
+      conn =
+        conn
+        |> put_req_header("authorization", "bearer " <> token)
+        |> put_req_header("content-type", "application/json")
+        |> post(~p"/api/v1/mcp", Jason.encode!(%{jsonrpc: "2.0", id: 1, method: "initialize"}))
+
+      assert json_response(conn, 200)["result"]["serverInfo"]["name"] == "ex338"
+    end
+
+    test "returns 401 for an unrecognized auth scheme", %{conn: conn} do
+      user = insert(:user)
+      token = Accounts.create_user_api_token(user, "test")
+
+      conn =
+        conn
+        |> put_req_header("authorization", "Basic " <> token)
+        |> put_req_header("content-type", "application/json")
+        |> post(~p"/api/v1/mcp", Jason.encode!(%{jsonrpc: "2.0", id: 1, method: "initialize"}))
+
+      assert json_response(conn, 401)["error"]
+    end
+
+    test "returns 405 with an Allow header for non-POST methods", %{conn: conn} do
+      for method <- [:get, :options, :put, :delete] do
+        conn = dispatch(conn, Ex338Web.Endpoint, method, ~p"/api/v1/mcp")
+
+        assert json_response(conn, 405)["error"] =~ "use POST"
+        assert get_resp_header(conn, "allow") == ["POST"]
+      end
+    end
   end
 
   describe "tools/list" do


### PR DESCRIPTION
Two spec deviations on `/api/v1/mcp` surfaced while debugging an MCP client that couldn't connect. Neither was the client's actual problem, but both are wrong and both mislead whoever hits them next.

## Case-insensitive auth scheme

`Ex338Web.Plugs.ApiAuth` pattern-matched the literal `"Bearer "`, so a client sending `bearer` got a 401 indistinguishable from a bad token. RFC 7235 defines the scheme as case-insensitive.

## 405 instead of 404 for non-POST

Only `post "/mcp"` was routed, so `GET` and `OPTIONS` fell through to the catch-all 404. A 404 reads as a wrong URL — it cost real time chasing a nonexistent typo and a transport mismatch that wasn't there. The endpoint implements the stateless Streamable HTTP transport, so there is genuinely no SSE stream to `GET`; the fix says that with a 405 plus an `Allow: POST` header.

The `match :*` route is declared after `post "/mcp"` so POST still reaches `:handle`, and sits outside the API pipelines so it answers before any token check and without content negotiation.

## Verification

Against production before the change: `POST` → 200, `GET` → 404, `OPTIONS` → 404, `bearer` (lowercase) → 401.

New tests cover the lowercase scheme, an unrecognized scheme (`Basic` → still 401), and 405 + `Allow` across `GET`/`OPTIONS`/`PUT`/`DELETE`. Full suite: 1080 tests, 0 failures. Format and `--warnings-as-errors` clean.

## Not addressed

The endpoint still sends no CORS headers. Production logs confirm no client is sending a preflight, so this is not currently a blocker — left out rather than adding unused surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017gc4JKFJ5nGPGoTsoLtwjd