### PR TITLE
Show private leagues to authorized users

### DIFF
--- a/lib/ex338/fantasy_leagues.ex
+++ b/lib/ex338/fantasy_leagues.ex
@@ -86,6 +86,17 @@ defmodule Ex338.FantasyLeagues do
     |> Enum.map(&load_team_standings_data/1)
   end
 
+  def get_homepage_leagues(user \\ nil) do
+    list_fantasy_leagues()
+    |> filter_visible_leagues(user)
+    |> Enum.filter(&main_navigation?/1)
+    |> Enum.map(&load_team_standings_data/1)
+  end
+
+  def main_navigation?(%FantasyLeague{navbar_display: :primary}), do: true
+  def main_navigation?(%FantasyLeague{private?: true, navbar_display: :hidden}), do: true
+  def main_navigation?(%FantasyLeague{}), do: false
+
   @doc """
   Returns true when the user is allowed to view the league. Public leagues are
   visible to everyone, admins see everything, and private leagues are only

--- a/lib/ex338_web/components/layouts.ex
+++ b/lib/ex338_web/components/layouts.ex
@@ -2,6 +2,8 @@ defmodule Ex338Web.Layouts do
   @moduledoc false
   use Ex338Web, :html
 
+  alias Ex338.FantasyLeagues
+
   embed_templates "layouts/*"
 
   def display(fantasy_leagues, navbar, draft_method \\ :redraft) do
@@ -12,6 +14,8 @@ defmodule Ex338Web.Layouts do
     |> sort_private_first()
     |> sort_by_year()
   end
+
+  defdelegate main_navigation?(fantasy_league), to: FantasyLeagues
 
   attr :current_route, :string, required: true
   attr :href, :string, required: true

--- a/lib/ex338_web/components/layouts/navbar.html.heex
+++ b/lib/ex338_web/components/layouts/navbar.html.heex
@@ -74,7 +74,7 @@
               aria-orientation="vertical"
               aria-labelledby="user-menu"
             >
-              <%= for team <- @current_user.fantasy_teams, team.fantasy_league.navbar_display == :primary do %>
+              <%= for team <- @current_user.fantasy_teams, main_navigation?(team.fantasy_league) do %>
                 <.link
                   href={~p"/fantasy_teams/#{team.id}"}
                   class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100"

--- a/lib/ex338_web/components/layouts/sidebar.html.heex
+++ b/lib/ex338_web/components/layouts/sidebar.html.heex
@@ -218,7 +218,7 @@
               <h3 class="px-3 font-semibold tracking-wider text-gray-500 uppercase text-smleading-4">
                 Fantasy Leagues
               </h3>
-              <%= for league <- @leagues, league.navbar_display == :primary do %>
+              <%= for league <- @leagues, main_navigation?(league) do %>
                 <.sidebar_mobile_link conn={@conn} href={~p"/fantasy_leagues/#{league.id}"}>
                   <.sidebar_mobile_svg>
                     <path d="M9 17v-2m3 2v-4m3 4v-6m2 10H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z">
@@ -443,7 +443,7 @@
             >
               Fantasy Leagues
             </h3>
-            <%= for league <- @leagues, league.navbar_display == :primary do %>
+            <%= for league <- @leagues, main_navigation?(league) do %>
               <.sidebar_link conn={@conn} href={~p"/fantasy_leagues/#{league.id}"}>
                 <.sidebar_svg>
                   <path d="M9 17v-2m3 2v-4m3 4v-6m2 10H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z">

--- a/lib/ex338_web/controllers/page_controller.ex
+++ b/lib/ex338_web/controllers/page_controller.ex
@@ -5,7 +5,7 @@ defmodule Ex338Web.PageController do
   alias Ex338.Rulebooks
 
   def index(conn, _params) do
-    leagues = FantasyLeagues.get_leagues_by_status("primary", conn.assigns.current_user)
+    leagues = FantasyLeagues.get_homepage_leagues(conn.assigns.current_user)
     season_records = FantasyLeagues.list_current_season_records()
     all_time_records = FantasyLeagues.list_current_all_time_records()
     winnings = FantasyLeagues.list_all_winnings()

--- a/test/ex338_web/components/layouts_test.exs
+++ b/test/ex338_web/components/layouts_test.exs
@@ -69,6 +69,32 @@ defmodule Ex338Web.LayoutsTest do
     end
   end
 
+  describe "main_navigation?/1" do
+    test "includes private leagues even when their navbar display is hidden" do
+      league = %FantasyLeague{private?: true, navbar_display: :hidden}
+
+      assert Layouts.main_navigation?(league)
+    end
+
+    test "includes primary public leagues" do
+      league = %FantasyLeague{private?: false, navbar_display: :primary}
+
+      assert Layouts.main_navigation?(league)
+    end
+
+    test "excludes non-primary public leagues" do
+      league = %FantasyLeague{private?: false, navbar_display: :hidden}
+
+      refute Layouts.main_navigation?(league)
+    end
+
+    test "excludes archived private leagues" do
+      league = %FantasyLeague{private?: true, navbar_display: :archived}
+
+      refute Layouts.main_navigation?(league)
+    end
+  end
+
   describe "show_nav_components?/1" do
     test "returns true if the navbar and sidebar should displayed", %{conn: conn} do
       conn = get(conn, "/")

--- a/test/ex338_web/controllers/page_controller_test.exs
+++ b/test/ex338_web/controllers/page_controller_test.exs
@@ -93,6 +93,54 @@ defmodule Ex338Web.PageControllerTest do
       assert String.contains?(conn.resp_body, team_4_points)
       assert String.contains?(conn.resp_body, team_4_winnings)
     end
+
+    test "shows a hidden private league to an owner", %{conn: conn} do
+      league =
+        insert(:fantasy_league,
+          fantasy_league_name: "Private Owner League",
+          navbar_display: "hidden",
+          private?: true
+        )
+
+      team = insert(:fantasy_team, fantasy_league: league)
+      user = insert(:user)
+      insert(:owner, fantasy_team: team, user: user)
+
+      conn = conn |> log_in_user(user) |> get("/")
+
+      assert Enum.map(conn.assigns.fantasy_leagues, & &1.id) == [league.id]
+      assert html_response(conn, 200) =~ "Private Owner League"
+    end
+
+    test "shows a hidden private league to an admin", %{conn: conn} do
+      league =
+        insert(:fantasy_league,
+          fantasy_league_name: "Private Admin League",
+          navbar_display: "hidden",
+          private?: true
+        )
+
+      admin = insert(:user, admin: true)
+      conn = conn |> log_in_user(admin) |> get("/")
+
+      assert Enum.map(conn.assigns.fantasy_leagues, & &1.id) == [league.id]
+      assert html_response(conn, 200) =~ "Private Admin League"
+    end
+
+    test "keeps a hidden private league hidden from a non-member", %{conn: conn} do
+      league =
+        insert(:fantasy_league,
+          fantasy_league_name: "Private Outsider League",
+          navbar_display: "hidden",
+          private?: true
+        )
+
+      outsider = insert(:user)
+      conn = conn |> log_in_user(outsider) |> get("/")
+
+      refute league.id in Enum.map(conn.assigns.fantasy_leagues, & &1.id)
+      refute html_response(conn, 200) =~ "Private Outsider League"
+    end
   end
 
   test "GET /rules from 2022 without user", %{conn: conn} do


### PR DESCRIPTION
## Summary

- show active private leagues in desktop and mobile navigation for authorized owners and admins
- include those leagues in homepage standings while preserving private-league access filtering
- centralize the main-navigation predicate across layouts and homepage selection

## Review fixes

- make homepage tests assert the controller's selected leagues so sidebar rendering cannot create a false positive
- exercise an authenticated non-member in the access regression test

## Verification

- `mix format --check-formatted`
- `mix compile --warnings-as-errors`
- `mix test` (1087 tests, 0 failures)