### PR TITLE
Protect private league API reads

### DIFF
--- a/lib/ex338_web/controllers/api/v1/fantasy_league_controller.ex
+++ b/lib/ex338_web/controllers/api/v1/fantasy_league_controller.ex
@@ -7,7 +7,11 @@ defmodule Ex338Web.Api.V1.FantasyLeagueController do
   action_fallback Ex338Web.Api.V1.FallbackController
 
   def index(conn, _params) do
-    fantasy_leagues = FantasyLeagues.list_leagues_by_status("primary")
+    fantasy_leagues =
+      "primary"
+      |> FantasyLeagues.list_leagues_by_status()
+      |> FantasyLeagues.filter_visible_leagues(conn.assigns[:current_user])
+
     render(conn, :index, fantasy_leagues: fantasy_leagues)
   end
 

--- a/lib/ex338_web/plugs/api_auth.ex
+++ b/lib/ex338_web/plugs/api_auth.ex
@@ -8,7 +8,9 @@ defmodule Ex338Web.Plugs.ApiAuth do
 
   Authorization (which teams/actions a user may touch) is handled downstream by
   `Ex338.Abilities`, exactly as in the HTML layer — this plug only establishes
-  identity.
+  identity. Authentication is required by default; read-only public API routes
+  pass `required: false` so anonymous callers can still read public leagues while
+  a supplied token is validated and establishes identity for private-league access.
   """
   import Phoenix.Controller
   import Plug.Conn
@@ -19,7 +21,17 @@ defmodule Ex338Web.Plugs.ApiAuth do
 
   def init(options), do: options
 
-  def call(conn, _opts) do
+  def call(conn, opts) do
+    case get_req_header(conn, "authorization") do
+      [] ->
+        if Keyword.get(opts, :required, true), do: unauthorized(conn), else: conn
+
+      _headers ->
+        authenticate(conn)
+    end
+  end
+
+  defp authenticate(conn) do
     with {:ok, token} <- fetch_bearer_token(conn),
          %UserToken{user: %User{} = user} = api_token <- Accounts.get_api_token(token) do
       conn

--- a/lib/ex338_web/plugs/require_api_league_access.ex
+++ b/lib/ex338_web/plugs/require_api_league_access.ex
@@ -1,0 +1,58 @@
+defmodule Ex338Web.Plugs.RequireApiLeagueAccess do
+  @moduledoc """
+  Protects API reads for private leagues while leaving public leagues public.
+
+  Anonymous callers receive 401 for a private league. Authenticated users who
+  do not own a team in the league receive 403; league members and admins pass.
+  """
+
+  import Phoenix.Controller
+  import Plug.Conn
+
+  alias Ex338.FantasyLeagues
+  alias Ex338Web.Api.V1.ErrorJSON
+
+  def init(options), do: options
+
+  def call(conn, _opts) do
+    league_id = conn.path_params["fantasy_league_id"] || conn.path_params["id"]
+
+    with {:ok, id} <- cast_id(league_id),
+         league when not is_nil(league) <- FantasyLeagues.get(id) do
+      if FantasyLeagues.can_access_league?(league, conn.assigns[:current_user]) do
+        assign(conn, :fantasy_league, league)
+      else
+        deny_access(conn)
+      end
+    else
+      _ -> respond(conn, :not_found, "Not found")
+    end
+  end
+
+  defp cast_id(id) when is_integer(id), do: {:ok, id}
+
+  defp cast_id(id) when is_binary(id) do
+    case Integer.parse(id) do
+      {int, ""} -> {:ok, int}
+      _ -> :error
+    end
+  end
+
+  defp cast_id(_id), do: :error
+
+  defp deny_access(%{assigns: %{current_user: _user}} = conn) do
+    respond(conn, :forbidden, "You are not authorized to view this private league")
+  end
+
+  defp deny_access(conn) do
+    respond(conn, :unauthorized, "An API token is required to view this private league")
+  end
+
+  defp respond(conn, status, message) do
+    conn
+    |> put_status(status)
+    |> put_view(json: ErrorJSON)
+    |> render(:error, message: message)
+    |> halt()
+  end
+end

--- a/lib/ex338_web/plugs/require_api_team_access.ex
+++ b/lib/ex338_web/plugs/require_api_team_access.ex
@@ -1,0 +1,44 @@
+defmodule Ex338Web.Plugs.RequireApiTeamAccess do
+  @moduledoc """
+  Protects API team reads according to the team's fantasy league visibility.
+  """
+
+  import Phoenix.Controller
+  import Plug.Conn
+
+  alias Ex338.FantasyLeagues
+  alias Ex338.FantasyTeams
+  alias Ex338Web.Api.V1.ErrorJSON
+
+  def init(options), do: options
+
+  def call(conn, _opts) do
+    case FantasyTeams.get_team_with_owners(conn.path_params["id"]) do
+      nil ->
+        respond(conn, :not_found, "Not found")
+
+      team ->
+        if FantasyLeagues.can_access_league?(team.fantasy_league, conn.assigns[:current_user]) do
+          assign(conn, :fantasy_team, team)
+        else
+          deny_access(conn)
+        end
+    end
+  end
+
+  defp deny_access(%{assigns: %{current_user: _user}} = conn) do
+    respond(conn, :forbidden, "You are not authorized to view this private league")
+  end
+
+  defp deny_access(conn) do
+    respond(conn, :unauthorized, "An API token is required to view this private league")
+  end
+
+  defp respond(conn, status, message) do
+    conn
+    |> put_status(status)
+    |> put_view(json: ErrorJSON)
+    |> render(:error, message: message)
+    |> halt()
+  end
+end

--- a/lib/ex338_web/router.ex
+++ b/lib/ex338_web/router.ex
@@ -11,6 +11,7 @@ defmodule Ex338Web.Router do
   import Phoenix.LiveDashboard.Router
 
   alias Ex338Web.Api.V1
+  alias Ex338Web.Plugs.ApiAuth
 
   pipeline :browser do
     plug(:accepts, ["html"])
@@ -44,9 +45,22 @@ defmodule Ex338Web.Router do
     plug(:accepts, ["json"])
   end
 
+  pipeline :api_read do
+    plug(:accepts, ["json"])
+    plug(ApiAuth, required: false)
+  end
+
+  pipeline :require_api_league_access do
+    plug(Ex338Web.Plugs.RequireApiLeagueAccess)
+  end
+
+  pipeline :require_api_team_access do
+    plug(Ex338Web.Plugs.RequireApiTeamAccess)
+  end
+
   pipeline :api_authenticated do
     plug(:accepts, ["json"])
-    plug(Ex338Web.Plugs.ApiAuth)
+    plug(ApiAuth)
   end
 
   scope "/", Ex338Web do
@@ -209,9 +223,15 @@ defmodule Ex338Web.Router do
   end
 
   scope "/api/v1", V1 do
-    pipe_through :api
+    pipe_through :api_read
 
-    resources "/fantasy_leagues", FantasyLeagueController, only: [:index, :show] do
+    resources "/fantasy_leagues", FantasyLeagueController, only: [:index]
+  end
+
+  scope "/api/v1", V1 do
+    pipe_through [:api_read, :require_api_league_access]
+
+    resources "/fantasy_leagues", FantasyLeagueController, only: [:show] do
       resources "/draft_picks", DraftPickController, only: [:index]
       resources "/waivers", WaiverController, only: [:index]
       resources "/championships", ChampionshipController, only: [:index, :show]
@@ -219,7 +239,10 @@ defmodule Ex338Web.Router do
       resources "/trades", TradeController, only: [:index]
       resources "/injured_reserves", InjuredReserveController, only: [:index]
     end
+  end
 
+  scope "/api/v1", V1 do
+    pipe_through [:api_read, :require_api_team_access]
     resources "/fantasy_teams", FantasyTeamController, only: [:show]
   end
 

--- a/test/ex338_web/controllers/api/v1/private_league_access_test.exs
+++ b/test/ex338_web/controllers/api/v1/private_league_access_test.exs
@@ -1,0 +1,128 @@
+defmodule Ex338Web.Api.V1.PrivateLeagueAccessTest do
+  use Ex338Web.ConnCase
+
+  alias Ex338.Accounts
+
+  defp auth(conn, user) do
+    token = Accounts.create_user_api_token(user, "test")
+    put_req_header(conn, "authorization", "Bearer " <> token)
+  end
+
+  describe "league index visibility" do
+    test "anonymous callers see public leagues but not private leagues", %{conn: conn} do
+      public = insert(:fantasy_league, navbar_display: "primary", private?: false)
+      private = insert(:fantasy_league, navbar_display: "primary", private?: true)
+
+      conn = get(conn, ~p"/api/v1/fantasy_leagues")
+
+      ids = conn |> json_response(200) |> get_in(["fantasy_leagues"]) |> Enum.map(& &1["id"])
+      assert public.id in ids
+      refute private.id in ids
+    end
+
+    test "members and admins see private leagues", %{conn: conn} do
+      private = insert(:fantasy_league, navbar_display: "primary", private?: true)
+      team = insert(:fantasy_team, fantasy_league: private)
+      member = insert(:user)
+      insert(:owner, fantasy_team: team, user: member)
+
+      member_conn = conn |> auth(member) |> get(~p"/api/v1/fantasy_leagues")
+
+      admin_conn =
+        conn |> recycle() |> auth(insert(:user, admin: true)) |> get(~p"/api/v1/fantasy_leagues")
+
+      assert private.id in league_ids(member_conn)
+      assert private.id in league_ids(admin_conn)
+    end
+
+    test "authenticated non-members do not see private leagues", %{conn: conn} do
+      private = insert(:fantasy_league, navbar_display: "primary", private?: true)
+
+      conn = conn |> auth(insert(:user)) |> get(~p"/api/v1/fantasy_leagues")
+
+      refute private.id in league_ids(conn)
+    end
+
+    test "an invalid supplied token returns 401", %{conn: conn} do
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer invalid")
+        |> get(~p"/api/v1/fantasy_leagues")
+
+      assert json_response(conn, 401)["error"]
+    end
+  end
+
+  describe "private league reads" do
+    setup do
+      league = insert(:fantasy_league, private?: true)
+      team = insert(:fantasy_team, fantasy_league: league)
+      member = insert(:user)
+      insert(:owner, fantasy_team: team, user: member)
+      %{league: league, member: member, team: team}
+    end
+
+    test "every league-scoped read requires a token", %{conn: conn, league: league} do
+      paths = [
+        ~p"/api/v1/fantasy_leagues/#{league.id}",
+        ~p"/api/v1/fantasy_leagues/#{league.id}/draft_picks",
+        ~p"/api/v1/fantasy_leagues/#{league.id}/waivers",
+        ~p"/api/v1/fantasy_leagues/#{league.id}/championships",
+        ~p"/api/v1/fantasy_leagues/#{league.id}/championships/0",
+        ~p"/api/v1/fantasy_leagues/#{league.id}/fantasy_players",
+        ~p"/api/v1/fantasy_leagues/#{league.id}/trades",
+        ~p"/api/v1/fantasy_leagues/#{league.id}/injured_reserves"
+      ]
+
+      for path <- paths do
+        response = conn |> recycle() |> get(path)
+        assert json_response(response, 401)["error"] =~ "API token"
+      end
+    end
+
+    test "members and admins can view a private league", context do
+      %{conn: conn, league: league, member: member} = context
+
+      member_conn = conn |> auth(member) |> get(~p"/api/v1/fantasy_leagues/#{league.id}")
+
+      admin_conn =
+        conn
+        |> recycle()
+        |> auth(insert(:user, admin: true))
+        |> get(~p"/api/v1/fantasy_leagues/#{league.id}")
+
+      assert json_response(member_conn, 200)["fantasy_league"]["id"] == league.id
+      assert json_response(admin_conn, 200)["fantasy_league"]["id"] == league.id
+    end
+
+    test "an authenticated non-member receives 403", %{conn: conn, league: league} do
+      conn = conn |> auth(insert(:user)) |> get(~p"/api/v1/fantasy_leagues/#{league.id}")
+
+      assert json_response(conn, 403)["error"] =~ "not authorized"
+    end
+
+    test "team reads use the team's private league access", context do
+      %{conn: conn, member: member, team: team} = context
+      path = ~p"/api/v1/fantasy_teams/#{team.id}"
+
+      assert conn |> recycle() |> get(path) |> json_response(401)
+      assert conn |> recycle() |> auth(insert(:user)) |> get(path) |> json_response(403)
+      assert conn |> recycle() |> auth(member) |> get(path) |> json_response(200)
+    end
+  end
+
+  test "public league and team reads remain anonymous", %{conn: conn} do
+    league = insert(:fantasy_league, private?: false)
+    team = insert(:fantasy_team, fantasy_league: league)
+
+    assert conn |> get(~p"/api/v1/fantasy_leagues/#{league.id}") |> json_response(200)
+    assert conn |> recycle() |> get(~p"/api/v1/fantasy_teams/#{team.id}") |> json_response(200)
+  end
+
+  defp league_ids(conn) do
+    conn
+    |> json_response(200)
+    |> get_in(["fantasy_leagues"])
+    |> Enum.map(& &1["id"])
+  end
+end


### PR DESCRIPTION
## Summary

- preserve anonymous REST reads for public leagues while optionally authenticating supplied API tokens
- hide private leagues from unauthenticated and non-member index responses
- require a Bearer API token plus owner/admin access for every private league and team read endpoint
- keep MCP behavior unchanged; it already requires authentication and enforces league membership

## Security behavior

- anonymous private read: `401 Unauthorized`
- invalid supplied token: `401 Unauthorized`
- authenticated non-member: `403 Forbidden`
- owner/admin: allowed
- anonymous public read: unchanged

## Verification

- `mix format --check-formatted`
- `mix compile --warnings-as-errors`
- `mix test` (1096 tests, 0 failures)