### PR TITLE
Keep skipped picks available after draft ends

### DIFF
--- a/lib/ex338/draft_picks/draft_pick.ex
+++ b/lib/ex338/draft_picks/draft_pick.ex
@@ -42,7 +42,9 @@ defmodule Ex338.DraftPicks.DraftPick do
 
     case find_index_of_next_team_under_limit(remaining_picks) do
       nil ->
-        false
+        remaining_picks
+        |> get_unfilled_picks()
+        |> draft_pick_available?(draft_pick_id)
 
       index_next_team_under_limit ->
         remaining_picks
@@ -98,7 +100,10 @@ defmodule Ex338.DraftPicks.DraftPick do
 
     case find_index_of_next_team_under_limit(remaining_picks) do
       nil ->
-        nil
+        case get_unfilled_picks(remaining_picks) do
+          [] -> nil
+          available_picks -> available_picks
+        end
 
       index_next_team_under_limit ->
         get_available_picks(remaining_picks, index_next_team_under_limit)
@@ -228,7 +233,11 @@ defmodule Ex338.DraftPicks.DraftPick do
   defp get_available_picks(remaining_picks, index_next_team_under_limit) do
     remaining_picks
     |> Enum.take(index_next_team_under_limit + 1)
-    |> Enum.reject(&(&1.fantasy_player_id !== nil))
+    |> get_unfilled_picks()
+  end
+
+  defp get_unfilled_picks(draft_picks) do
+    Enum.reject(draft_picks, &(&1.fantasy_player_id !== nil))
   end
 
   defp draft_pick_available?(available_picks, draft_pick_id) do

--- a/test/ex338/draft_picks/draft_pick_test.exs
+++ b/test/ex338/draft_picks/draft_pick_test.exs
@@ -295,6 +295,40 @@ defmodule Ex338.DraftPicks.DraftPickTest do
       assert DraftPick.available_with_skipped_picks?(not_available.id, draft_picks) == false
     end
 
+    test "keeps every skipped pick available when no under-limit pick remains" do
+      team_a = %{over_draft_time_limit?: false}
+      skipped_team = %{over_draft_time_limit?: true}
+
+      completed_pick = %{id: 1, draft_position: 1, fantasy_player_id: 1, fantasy_team: team_a}
+
+      skipped_pick = %{
+        id: 2,
+        draft_position: 2,
+        fantasy_player_id: nil,
+        fantasy_team: skipped_team
+      }
+
+      later_completed_pick = %{
+        id: 3,
+        draft_position: 3,
+        fantasy_player_id: 2,
+        fantasy_team: team_a
+      }
+
+      skipped_pick2 = %{
+        id: 4,
+        draft_position: 4,
+        fantasy_player_id: nil,
+        fantasy_team: skipped_team
+      }
+
+      draft_picks = [completed_pick, skipped_pick, later_completed_pick, skipped_pick2]
+
+      assert DraftPick.available_with_skipped_picks?(skipped_pick.id, draft_picks)
+      assert DraftPick.available_with_skipped_picks?(skipped_pick2.id, draft_picks)
+      refute DraftPick.available_with_skipped_picks?(later_completed_pick.id, draft_picks)
+    end
+
     test "returns false when no pick is available to make" do
       team_a = %{over_draft_time_limit?: false}
 
@@ -355,6 +389,40 @@ defmodule Ex338.DraftPicks.DraftPickTest do
       draft_picks = [completed_pick]
 
       assert DraftPick.picks_available_with_skips(draft_picks) == nil
+    end
+
+    test "keeps every skipped pick in the available picks when no under-limit pick remains" do
+      team_a = %{over_draft_time_limit?: false}
+      skipped_team = %{over_draft_time_limit?: true}
+
+      completed_pick = %{id: 1, draft_position: 1, fantasy_player_id: 1, fantasy_team: team_a}
+
+      skipped_pick = %{
+        id: 2,
+        draft_position: 2,
+        fantasy_player_id: nil,
+        fantasy_team: skipped_team
+      }
+
+      later_completed_pick = %{
+        id: 3,
+        draft_position: 3,
+        fantasy_player_id: 2,
+        fantasy_team: team_a
+      }
+
+      skipped_pick2 = %{
+        id: 4,
+        draft_position: 4,
+        fantasy_player_id: nil,
+        fantasy_team: skipped_team
+      }
+
+      draft_picks = [completed_pick, skipped_pick, later_completed_pick, skipped_pick2]
+
+      results = DraftPick.picks_available_with_skips(draft_picks)
+
+      assert Enum.map(results, & &1.id) == [skipped_pick.id, skipped_pick2.id]
     end
 
     test "returns available picks when skip pick is made" do


### PR DESCRIPTION
## Summary

- keep every remaining skipped pick available when no under-limit team remains in the draft
- keep completed picks unavailable when they are interleaved with skipped picks
- preserve the completed-draft behavior when no unfilled picks remain
- add regression coverage for keeping skipped picks available at the end of the draft

## Context

League 102 ended with multiple skipped picks. Skipped picks remain available while later picks proceed, but the availability calculation used the next unfilled pick from an under-limit team as its boundary. When every remaining team was already over the time limit, the calculation stopped treating those skipped picks as available. That hid Submit Pick and caused owner submissions to fail validation.

## Verification

- mix format --check-formatted
- mix compile --warnings-as-errors
- mix test (1104 tests, 0 failures)